### PR TITLE
Redirect add supplier button to add supplier form

### DIFF
--- a/suppliers.php
+++ b/suppliers.php
@@ -440,22 +440,8 @@ $totalSuppliers = count($suppliers);
             }
 
             if (addButton) {
-                addButton.addEventListener('click', async () => {
-                    const data = collectSupplierData({});
-                    if (!data) {
-                        return;
-                    }
-
-                    addButton.disabled = true;
-
-                    try {
-                        await requestSupplier('api/suppliers/add.php', data);
-                        window.location.reload();
-                    } catch (error) {
-                        window.alert(error instanceof Error ? error.message : 'Bir hata oluştu.');
-                    } finally {
-                        addButton.disabled = false;
-                    }
+                addButton.addEventListener('click', () => {
+                    window.location.href = '/api/suppliers/add.php';
                 });
             }
 


### PR DESCRIPTION
## Summary
- redirect the "Yeni Tedarikçi Ekle" button to the add-supplier form at /api/suppliers/add.php for direct navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da531c646c83289f9a0c88d178ece9