### PR TITLE
Prefill supplier edit form with existing data

### DIFF
--- a/suppliers.php
+++ b/suppliers.php
@@ -467,7 +467,7 @@ $totalSuppliers = count($suppliers);
 
                 if (editButton) {
                     editButton.addEventListener('click', () => {
-                        const targetUrl = new URL('api/suppliers/edit.php', window.location.origin);
+                        const targetUrl = new URL('api/suppliers/edit.php', window.location.href);
                         targetUrl.searchParams.set('id', String(supplierData.id));
 
                         window.location.href = targetUrl.toString();


### PR DESCRIPTION
## Summary
- load supplier details during GET requests when an id query parameter is provided
- pre-populate the supplier edit form inputs and surface lookup errors in the UI
- fix the supplier edit navigation so redirects keep the application base path

## Testing
- php -l suppliers.php
- php -l api/suppliers/edit.php

------
https://chatgpt.com/codex/tasks/task_e_68da5a5f90248328b0f9cc8409e02d9a