### PR TITLE
Apply new grayscale color palette

### DIFF
--- a/api/suppliers/add.php
+++ b/api/suppliers/add.php
@@ -12,21 +12,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         <style>
             :root {
                 color-scheme: light dark;
-                --bg-color: #f5f7fb;
+                --bg-color: #e1e1e1;
                 --card-bg: #ffffff;
-                --primary: #4f46e5;
-                --primary-dark: #4338ca;
-                --danger: #dc2626;
-                --text-color: #1f2937;
-                --muted-text: #6b7280;
+                --primary: #282828;
+                --primary-dark: #464646;
+                --text-color: #282828;
+                --muted-text: #464646;
+                --border-color: rgba(125, 125, 125, 0.45);
             }
 
             @media (prefers-color-scheme: dark) {
                 :root {
-                    --bg-color: #0f172a;
-                    --card-bg: #111827;
-                    --text-color: #e5e7eb;
-                    --muted-text: #9ca3af;
+                    --bg-color: #282828;
+                    --card-bg: #353535;
+                    --text-color: #ffffff;
+                    --muted-text: #e1e1e1;
+                    --border-color: rgba(225, 225, 225, 0.25);
                 }
             }
 
@@ -45,7 +46,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             .card {
                 background: var(--card-bg);
                 border-radius: 16px;
-                box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+                box-shadow: 0 20px 45px rgba(40, 40, 40, 0.18);
                 padding: 32px;
                 width: min(560px, 100%);
             }
@@ -77,17 +78,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 width: 100%;
                 padding: 12px 14px;
                 border-radius: 10px;
-                border: 1px solid rgba(79, 70, 229, 0.25);
+                border: 1px solid var(--border-color);
                 font-size: 1rem;
                 transition: border-color 0.2s ease, box-shadow 0.2s ease;
-                background: transparent;
-                color: inherit;
+                background: var(--card-bg);
+                color: var(--text-color);
             }
 
             input:focus, textarea:focus {
                 outline: none;
-                border-color: var(--primary);
-                box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.15);
+                border-color: var(--primary-dark);
+                box-shadow: 0 0 0 4px rgba(70, 70, 70, 0.15);
             }
 
             .actions {
@@ -110,12 +111,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             button.primary {
                 background: linear-gradient(135deg, var(--primary), var(--primary-dark));
                 color: #fff;
-                box-shadow: 0 10px 30px rgba(79, 70, 229, 0.35);
+                box-shadow: 0 10px 30px rgba(40, 40, 40, 0.3);
             }
 
             button.primary:hover {
                 transform: translateY(-1px);
-                box-shadow: 0 16px 40px rgba(79, 70, 229, 0.45);
+                box-shadow: 0 16px 40px rgba(40, 40, 40, 0.35);
             }
 
             .status {
@@ -128,14 +129,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
             .status.success {
                 display: block;
-                background: rgba(22, 163, 74, 0.12);
-                color: #15803d;
+                background: rgba(125, 125, 125, 0.12);
+                color: var(--text-color);
+                border-left: 4px solid #7d7d7d;
             }
 
             .status.error {
                 display: block;
-                background: rgba(220, 38, 38, 0.12);
-                color: var(--danger);
+                background: rgba(40, 40, 40, 0.08);
+                color: var(--text-color);
+                border-left: 4px solid #282828;
             }
 
             .status pre {

--- a/api/suppliers/edit.php
+++ b/api/suppliers/edit.php
@@ -63,21 +63,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         <style>
             :root {
                 color-scheme: light dark;
-                --bg-color: #eef2ff;
+                --bg-color: #e1e1e1;
                 --card-bg: #ffffff;
-                --primary: #2563eb;
-                --primary-dark: #1d4ed8;
-                --danger: #dc2626;
-                --text-color: #111827;
-                --muted-text: #6b7280;
+                --primary: #282828;
+                --primary-dark: #464646;
+                --text-color: #282828;
+                --muted-text: #464646;
+                --border-color: rgba(125, 125, 125, 0.45);
             }
 
             @media (prefers-color-scheme: dark) {
                 :root {
-                    --bg-color: #0b1220;
-                    --card-bg: #111827;
-                    --text-color: #e5e7eb;
-                    --muted-text: #9ca3af;
+                    --bg-color: #282828;
+                    --card-bg: #353535;
+                    --text-color: #ffffff;
+                    --muted-text: #e1e1e1;
+                    --border-color: rgba(225, 225, 225, 0.25);
                 }
             }
 
@@ -98,7 +99,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 border-radius: 18px;
                 padding: 36px;
                 width: min(620px, 100%);
-                box-shadow: 0 25px 50px rgba(37, 99, 235, 0.2);
+                box-shadow: 0 25px 50px rgba(40, 40, 40, 0.2);
             }
 
             h1 {
@@ -127,17 +128,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 width: 100%;
                 padding: 12px 14px;
                 border-radius: 10px;
-                border: 1px solid rgba(37, 99, 235, 0.25);
+                border: 1px solid var(--border-color);
                 font-size: 1rem;
-                background: transparent;
+                background: var(--card-bg);
                 transition: border-color 0.2s ease, box-shadow 0.2s ease;
-                color: inherit;
+                color: var(--text-color);
             }
 
             input:focus, textarea:focus {
                 outline: none;
-                border-color: var(--primary);
-                box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+                border-color: var(--primary-dark);
+                box-shadow: 0 0 0 4px rgba(70, 70, 70, 0.15);
             }
 
             .actions {
@@ -160,12 +161,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             button.primary {
                 background: linear-gradient(135deg, var(--primary), var(--primary-dark));
                 color: #fff;
-                box-shadow: 0 10px 32px rgba(37, 99, 235, 0.35);
+                box-shadow: 0 10px 32px rgba(40, 40, 40, 0.3);
             }
 
             button.primary:hover {
                 transform: translateY(-1px);
-                box-shadow: 0 14px 36px rgba(37, 99, 235, 0.4);
+                box-shadow: 0 14px 36px rgba(40, 40, 40, 0.35);
             }
 
             .status {
@@ -178,14 +179,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
             .status.success {
                 display: block;
-                background: rgba(22, 163, 74, 0.12);
-                color: #15803d;
+                background: rgba(125, 125, 125, 0.12);
+                color: var(--text-color);
+                border-left: 4px solid #7d7d7d;
             }
 
             .status.error {
                 display: block;
-                background: rgba(220, 38, 38, 0.12);
-                color: var(--danger);
+                background: rgba(40, 40, 40, 0.08);
+                color: var(--text-color);
+                border-left: 4px solid #282828;
             }
 
             .status pre {

--- a/dashboard.php
+++ b/dashboard.php
@@ -101,8 +101,8 @@ $metricData = array_map(
         body {
             margin: 0;
             font-family: "Inter", Arial, sans-serif;
-            background: #0f172a;
-            color: #f8fafc;
+            background: #282828;
+            color: #ffffff;
         }
 
         main {
@@ -112,11 +112,11 @@ $metricData = array_map(
         }
 
         .intro {
-            background: linear-gradient(135deg, rgba(99, 102, 241, 0.1), rgba(14, 165, 233, 0.12));
-            border: 1px solid rgba(148, 163, 184, 0.2);
+            background: linear-gradient(135deg, rgba(70, 70, 70, 0.35), rgba(125, 125, 125, 0.25));
+            border: 1px solid rgba(225, 225, 225, 0.12);
             border-radius: 20px;
             padding: 2.5rem;
-            box-shadow: 0 20px 55px rgba(15, 23, 42, 0.35);
+            box-shadow: 0 20px 55px rgba(40, 40, 40, 0.35);
         }
 
         .intro h1 {
@@ -127,7 +127,7 @@ $metricData = array_map(
 
         .intro p {
             margin: 0;
-            color: #cbd5f5;
+            color: #e1e1e1;
             font-size: 1.05rem;
             max-width: 680px;
             line-height: 1.6;
@@ -140,11 +140,11 @@ $metricData = array_map(
         }
 
         .card {
-            background: rgba(15, 23, 42, 0.85);
+            background: rgba(40, 40, 40, 0.85);
             border-radius: 18px;
             padding: 1.75rem;
-            border: 1px solid rgba(148, 163, 184, 0.2);
-            box-shadow: 0 12px 32px rgba(15, 23, 42, 0.35);
+            border: 1px solid rgba(125, 125, 125, 0.3);
+            box-shadow: 0 12px 32px rgba(40, 40, 40, 0.35);
             display: flex;
             flex-direction: column;
             gap: 0.75rem;
@@ -153,18 +153,18 @@ $metricData = array_map(
 
         .card:hover {
             transform: translateY(-4px);
-            border-color: rgba(99, 102, 241, 0.6);
+            border-color: rgba(225, 225, 225, 0.4);
         }
 
         .card h2 {
             margin: 0;
             font-size: 1.25rem;
-            color: #e0e7ff;
+            color: #e1e1e1;
         }
 
         .card p {
             margin: 0;
-            color: #cbd5f5;
+            color: #e1e1e1;
             line-height: 1.5;
         }
 
@@ -175,11 +175,11 @@ $metricData = array_map(
         }
 
         .metric-tile {
-            background: rgba(30, 64, 175, 0.4);
+            background: rgba(70, 70, 70, 0.45);
             border-radius: 16px;
             padding: 1.5rem;
             text-align: center;
-            border: 1px solid rgba(96, 165, 250, 0.4);
+            border: 1px solid rgba(225, 225, 225, 0.2);
         }
 
         .metric-tile h3 {
@@ -187,7 +187,7 @@ $metricData = array_map(
             font-size: 0.95rem;
             letter-spacing: 0.06em;
             text-transform: uppercase;
-            color: #bfdbfe;
+            color: #e1e1e1;
         }
 
         .metric-tile span {
@@ -201,8 +201,8 @@ $metricData = array_map(
             justify-content: center;
             font-size: 0.9rem;
             font-weight: 500;
-            color: #bfdbfe;
-            background: rgba(30, 64, 175, 0.25);
+            color: #ffffff;
+            background: rgba(125, 125, 125, 0.25);
             border-radius: 999px;
             padding: 0.35rem 0.85rem;
         }

--- a/header.php
+++ b/header.php
@@ -19,9 +19,9 @@ if (!function_exists('nexaHeaderStyles')) {
         align-items: center;
         justify-content: space-between;
         padding: 1rem 2.5rem;
-        background: #111827;
-        color: #f9fafb;
-        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.25);
+        background: #282828;
+        color: #ffffff;
+        box-shadow: 0 10px 24px rgba(40, 40, 40, 0.25);
     }
 
     .nexa-logo {
@@ -41,7 +41,7 @@ if (!function_exists('nexaHeaderStyles')) {
         width: 42px;
         height: 42px;
         border-radius: 12px;
-        background: linear-gradient(135deg, #6366f1, #ec4899);
+        background: linear-gradient(135deg, #464646, #7d7d7d);
         align-items: center;
         justify-content: center;
         font-size: 1.15rem;
@@ -56,7 +56,7 @@ if (!function_exists('nexaHeaderStyles')) {
     }
 
     .nexa-nav a {
-        color: #e5e7eb;
+        color: #e1e1e1;
         text-decoration: none;
         font-weight: 500;
         letter-spacing: 0.01em;
@@ -87,7 +87,7 @@ if (!function_exists('nexaHeaderStyles')) {
         gap: 0.5rem;
         padding: 0.6rem 1.4rem;
         border-radius: 999px;
-        background: #2563eb;
+        background: #464646;
         color: #ffffff;
         border: none;
         cursor: pointer;
@@ -98,7 +98,8 @@ if (!function_exists('nexaHeaderStyles')) {
 
     .nexa-profile-toggle:focus,
     .nexa-profile-toggle:hover {
-        background: #1d4ed8;
+        background: #7d7d7d;
+        color: #282828;
         transform: translateY(-1px);
     }
 
@@ -113,9 +114,10 @@ if (!function_exists('nexaHeaderStyles')) {
         right: 0;
         margin-top: 0.5rem;
         min-width: 180px;
-        background: #1f2937;
+        background: #2f2f2f;
         border-radius: 12px;
-        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+        border: 1px solid #464646;
+        box-shadow: 0 12px 24px rgba(40, 40, 40, 0.35);
         padding: 0.4rem;
         display: flex;
         flex-direction: column;
@@ -127,7 +129,7 @@ if (!function_exists('nexaHeaderStyles')) {
         display: block;
         padding: 0.6rem 0.9rem;
         border-radius: 8px;
-        color: #f9fafb;
+        color: #e1e1e1;
         text-decoration: none;
         font-weight: 500;
         transition: background 0.2s ease;
@@ -135,7 +137,8 @@ if (!function_exists('nexaHeaderStyles')) {
 
     .nexa-profile-menu a:hover,
     .nexa-profile-menu a:focus {
-        background: rgba(59, 130, 246, 0.25);
+        background: rgba(225, 225, 225, 0.12);
+        color: #ffffff;
     }
 
     .nexa-profile-dropdown:not([open]) .nexa-profile-menu {

--- a/index.php
+++ b/index.php
@@ -13,7 +13,8 @@
             min-height: 100vh;
             align-items: center;
             justify-content: center;
-            background: #f4f6f8;
+            background: #e1e1e1;
+            color: #282828;
         }
 
         .container {
@@ -21,18 +22,18 @@
             background: #ffffff;
             padding: 3rem 4rem;
             border-radius: 12px;
-            box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+            box-shadow: 0 20px 45px rgba(40, 40, 40, 0.18);
         }
 
         h1 {
             margin-bottom: 1.5rem;
-            color: #1f2933;
+            color: #282828;
             font-size: 2.25rem;
         }
 
         p {
             margin-bottom: 2.5rem;
-            color: #52606d;
+            color: #464646;
             font-size: 1.1rem;
         }
 
@@ -58,16 +59,16 @@
 
         .actions button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 12px 22px rgba(79, 70, 229, 0.25);
+            box-shadow: 0 12px 22px rgba(70, 70, 70, 0.25);
         }
 
         .login {
-            background: #6366f1;
+            background: #282828;
             color: #ffffff;
         }
 
         .register {
-            background: #f97316;
+            background: #464646;
             color: #ffffff;
         }
     </style>

--- a/login.php
+++ b/login.php
@@ -68,26 +68,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <style>
         body {
             font-family: Arial, Helvetica, sans-serif;
-            background: #f4f6f8;
+            background: #e1e1e1;
             margin: 0;
             display: flex;
             align-items: center;
             justify-content: center;
             min-height: 100vh;
+            color: #282828;
         }
 
         .card {
             background: #ffffff;
             padding: 2.5rem 3rem;
             border-radius: 12px;
-            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+            box-shadow: 0 18px 40px rgba(40, 40, 40, 0.18);
             width: min(100%, 420px);
         }
 
         h1 {
             margin-top: 0;
             margin-bottom: 1.5rem;
-            color: #1f2933;
+            color: #282828;
             text-align: center;
         }
 
@@ -101,29 +102,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             flex-direction: column;
             gap: 0.4rem;
             font-weight: 600;
-            color: #334155;
+            color: #464646;
         }
 
         input {
             padding: 0.75rem 1rem;
             border-radius: 8px;
-            border: 1px solid #cbd5f5;
+            border: 1px solid #7d7d7d;
             font-size: 1rem;
+            background: #ffffff;
+            color: #282828;
         }
 
         button {
             padding: 0.9rem 1.2rem;
             border: none;
             border-radius: 999px;
-            background: #6366f1;
+            background: #282828;
             color: #ffffff;
             font-size: 1rem;
             cursor: pointer;
-            transition: background 0.2s ease;
+            transition: background 0.2s ease, color 0.2s ease;
         }
 
         button:hover {
-            background: #4f46e5;
+            background: #464646;
+            color: #ffffff;
         }
 
         .messages {
@@ -135,31 +139,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         .error {
             padding: 0.75rem 1rem;
             border-radius: 8px;
-            background: #fee2e2;
-            color: #991b1b;
+            background: rgba(40, 40, 40, 0.08);
+            color: #282828;
+            border-left: 4px solid #282828;
         }
 
         .success {
             padding: 0.75rem 1rem;
             border-radius: 8px;
-            background: #dcfce7;
-            color: #166534;
+            background: rgba(125, 125, 125, 0.12);
+            color: #282828;
+            border-left: 4px solid #7d7d7d;
         }
 
         .redirect {
             margin-top: 1.25rem;
             text-align: center;
-            color: #52606d;
+            color: #464646;
         }
 
         .redirect a {
-            color: #4f46e5;
+            color: #282828;
             text-decoration: none;
             font-weight: 600;
         }
 
         .redirect a:hover {
             text-decoration: underline;
+            color: #464646;
         }
     </style>
 </head>

--- a/register.php
+++ b/register.php
@@ -81,26 +81,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <style>
         body {
             font-family: Arial, Helvetica, sans-serif;
-            background: #f4f6f8;
+            background: #e1e1e1;
             margin: 0;
             display: flex;
             align-items: center;
             justify-content: center;
             min-height: 100vh;
+            color: #282828;
         }
 
         .card {
             background: #ffffff;
             padding: 2.5rem 3rem;
             border-radius: 12px;
-            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+            box-shadow: 0 18px 40px rgba(40, 40, 40, 0.18);
             width: min(100%, 480px);
         }
 
         h1 {
             margin-top: 0;
             margin-bottom: 1.5rem;
-            color: #1f2933;
+            color: #282828;
             text-align: center;
         }
 
@@ -114,29 +115,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             flex-direction: column;
             gap: 0.4rem;
             font-weight: 600;
-            color: #334155;
+            color: #464646;
         }
 
         input {
             padding: 0.75rem 1rem;
             border-radius: 8px;
-            border: 1px solid #cbd5f5;
+            border: 1px solid #7d7d7d;
             font-size: 1rem;
+            background: #ffffff;
+            color: #282828;
         }
 
         button {
             padding: 0.9rem 1.2rem;
             border: none;
             border-radius: 999px;
-            background: #6366f1;
+            background: #282828;
             color: #ffffff;
             font-size: 1rem;
             cursor: pointer;
-            transition: background 0.2s ease;
+            transition: background 0.2s ease, color 0.2s ease;
         }
 
         button:hover {
-            background: #4f46e5;
+            background: #464646;
+            color: #ffffff;
         }
 
         .messages {
@@ -148,15 +152,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         .error {
             padding: 0.75rem 1rem;
             border-radius: 8px;
-            background: #fee2e2;
-            color: #991b1b;
+            background: rgba(40, 40, 40, 0.08);
+            color: #282828;
+            border-left: 4px solid #282828;
         }
 
         .success {
             padding: 0.75rem 1rem;
             border-radius: 8px;
-            background: #dcfce7;
-            color: #166534;
+            background: rgba(125, 125, 125, 0.12);
+            color: #282828;
+            border-left: 4px solid #7d7d7d;
         }
 
         .back-link {
@@ -165,13 +171,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         .back-link a {
-            color: #6366f1;
+            color: #282828;
             text-decoration: none;
             font-weight: 600;
         }
 
         .back-link a:hover {
             text-decoration: underline;
+            color: #464646;
         }
     </style>
 </head>

--- a/suppliers.php
+++ b/suppliers.php
@@ -68,8 +68,8 @@ $totalSuppliers = count($suppliers);
         body {
             margin: 0;
             font-family: "Inter", Arial, sans-serif;
-            background: #0f172a;
-            color: #f8fafc;
+            background: #282828;
+            color: #ffffff;
         }
 
         main {
@@ -81,11 +81,11 @@ $totalSuppliers = count($suppliers);
         }
 
         .hero {
-            background: linear-gradient(135deg, rgba(99, 102, 241, 0.15), rgba(236, 72, 153, 0.12));
-            border: 1px solid rgba(148, 163, 184, 0.18);
+            background: linear-gradient(135deg, rgba(70, 70, 70, 0.35), rgba(125, 125, 125, 0.25));
+            border: 1px solid rgba(225, 225, 225, 0.12);
             border-radius: 20px;
             padding: 2.5rem;
-            box-shadow: 0 20px 55px rgba(15, 23, 42, 0.35);
+            box-shadow: 0 20px 55px rgba(40, 40, 40, 0.35);
         }
 
         .hero h1 {
@@ -96,7 +96,7 @@ $totalSuppliers = count($suppliers);
 
         .hero p {
             margin: 0;
-            color: #cbd5f5;
+            color: #e1e1e1;
             font-size: 1.1rem;
             max-width: 720px;
             line-height: 1.6;
@@ -107,25 +107,25 @@ $totalSuppliers = count($suppliers);
             display: inline-flex;
             align-items: center;
             gap: 0.75rem;
-            background: rgba(15, 23, 42, 0.6);
+            background: rgba(40, 40, 40, 0.6);
             padding: 0.85rem 1.25rem;
             border-radius: 999px;
-            border: 1px solid rgba(99, 102, 241, 0.45);
-            color: #e0e7ff;
+            border: 1px solid rgba(125, 125, 125, 0.35);
+            color: #ffffff;
             font-weight: 600;
         }
 
         .table-card {
-            background: rgba(15, 23, 42, 0.92);
+            background: rgba(40, 40, 40, 0.92);
             border-radius: 18px;
-            border: 1px solid rgba(148, 163, 184, 0.2);
-            box-shadow: 0 16px 35px rgba(15, 23, 42, 0.35);
+            border: 1px solid rgba(125, 125, 125, 0.25);
+            box-shadow: 0 16px 35px rgba(40, 40, 40, 0.35);
             overflow: hidden;
         }
 
         .table-header {
             padding: 1.5rem 2rem;
-            border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+            border-bottom: 1px solid rgba(225, 225, 225, 0.12);
             display: flex;
             flex-wrap: wrap;
             align-items: center;
@@ -155,29 +155,29 @@ $totalSuppliers = count($suppliers);
         }
 
         .table-actions button:focus-visible {
-            outline: 2px solid rgba(96, 165, 250, 0.65);
+            outline: 2px solid rgba(225, 225, 225, 0.65);
             outline-offset: 2px;
         }
 
         .action-add {
-            background: linear-gradient(135deg, rgba(96, 165, 250, 0.95), rgba(59, 130, 246, 0.95));
-            color: #0f172a;
-            box-shadow: 0 10px 20px rgba(37, 99, 235, 0.35);
+            background: linear-gradient(135deg, #282828, #464646);
+            color: #ffffff;
+            box-shadow: 0 10px 20px rgba(40, 40, 40, 0.4);
         }
 
         .action-edit {
-            background: rgba(251, 191, 36, 0.25);
-            color: #fbbf24;
+            background: rgba(125, 125, 125, 0.2);
+            color: #e1e1e1;
         }
 
         .action-delete {
-            background: rgba(248, 113, 113, 0.22);
-            color: #f87171;
+            background: rgba(70, 70, 70, 0.25);
+            color: #ffffff;
         }
 
         .table-actions button:hover {
             transform: translateY(-1px);
-            box-shadow: 0 12px 18px rgba(15, 23, 42, 0.25);
+            box-shadow: 0 12px 18px rgba(40, 40, 40, 0.25);
         }
 
         .table-actions button:disabled {
@@ -198,7 +198,7 @@ $totalSuppliers = count($suppliers);
         }
 
         thead {
-            background: rgba(30, 41, 59, 0.8);
+            background: rgba(70, 70, 70, 0.65);
         }
 
         th,
@@ -210,34 +210,35 @@ $totalSuppliers = count($suppliers);
 
         th {
             font-weight: 600;
-            color: #cbd5f5;
+            color: #e1e1e1;
             font-size: 0.95rem;
         }
 
         td {
-            color: #e2e8f0;
+            color: #ffffff;
             font-size: 0.95rem;
         }
 
         tbody tr:hover {
-            background: rgba(99, 102, 241, 0.08);
+            background: rgba(125, 125, 125, 0.15);
         }
 
         .empty-state {
             padding: 2.5rem;
             text-align: center;
-            color: #94a3b8;
+            color: #e1e1e1;
             font-size: 1rem;
         }
 
         a.supplier-link {
-            color: #60a5fa;
+            color: #e1e1e1;
             text-decoration: none;
         }
 
         a.supplier-link:hover,
         a.supplier-link:focus {
             text-decoration: underline;
+            color: #ffffff;
         }
 
         @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- restyle the shared header with the updated grayscale palette and refined hover states
- refresh the landing, authentication, dashboard, and supplier screens to use the new neutral tones
- align the supplier management API forms with shared grayscale variables and messaging treatments

## Testing
- for file in api/suppliers/add.php api/suppliers/edit.php dashboard.php header.php index.php login.php register.php suppliers.php; do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68da5d3b821483289318b805b92fd249