### PR TITLE
Add WAMP database configuration

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Database configuration for WAMP environment.
+ *
+ * This file creates a mysqli connection to the `nexa` database using
+ * typical default WAMP credentials. Update the credentials if your
+ * local environment differs.
+ */
+
+$host = '127.0.0.1';
+$username = 'root';
+$password = '';
+$database = 'nexa';
+
+$mysqli = new mysqli($host, $username, $password, $database);
+
+if ($mysqli->connect_errno) {
+    die('Database connection failed: ' . $mysqli->connect_error);
+}
+
+// Ensure UTF-8 encoding is used for the connection.
+if (! $mysqli->set_charset('utf8mb4')) {
+    die('Error loading character set utf8mb4: ' . $mysqli->error);
+}
+
+?>


### PR DESCRIPTION
## Summary
- add a PHP configuration file for connecting to the nexa database in a WAMP environment
- ensure the mysqli connection defaults to utf8mb4 encoding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db7e5095708328aa444c5b2f79b87d