### PR TITLE
Add supplier management interface and CRUD APIs

### DIFF
--- a/api/product/add.php
+++ b/api/product/add.php
@@ -20,12 +20,22 @@ if (! is_array($data)) {
 
 $name = isset($data['name']) ? trim($data['name']) : '';
 $type = isset($data['type']) ? trim($data['type']) : '';
+$allowedTypes = ['Isıcam', 'Tekcam'];
 
 if ($name === '') {
     http_response_code(422);
     echo json_encode([
         'success' => false,
         'message' => 'Lütfen ürün adını belirtin.'
+    ], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+if ($type !== '' && ! in_array($type, $allowedTypes, true)) {
+    http_response_code(422);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Geçerli bir cam türü seçiniz.'
     ], JSON_UNESCAPED_UNICODE);
     exit;
 }

--- a/api/product/edit.php
+++ b/api/product/edit.php
@@ -22,6 +22,7 @@ if (! is_array($data)) {
 $id = isset($data['id']) ? (int) $data['id'] : 0;
 $name = isset($data['name']) ? trim($data['name']) : '';
 $type = isset($data['type']) ? trim($data['type']) : '';
+$allowedTypes = ['Isıcam', 'Tekcam'];
 
 if ($id <= 0) {
     http_response_code(422);
@@ -37,6 +38,15 @@ if ($name === '') {
     echo json_encode([
         'success' => false,
         'message' => 'Ürün adı boş bırakılamaz.'
+    ], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+if ($type !== '' && ! in_array($type, $allowedTypes, true)) {
+    http_response_code(422);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Geçerli bir cam türü seçiniz.'
     ], JSON_UNESCAPED_UNICODE);
     exit;
 }

--- a/products.php
+++ b/products.php
@@ -175,14 +175,16 @@ require_once __DIR__ . '/header.php';
                 font-weight: 600;
             }
 
-            .modal input {
+            .modal input,
+            .modal select {
                 padding: 10px 12px;
                 border-radius: 8px;
                 border: 1px solid #d1d5db;
                 font-size: 1rem;
             }
 
-            .modal input:focus {
+            .modal input:focus,
+            .modal select:focus {
                 outline: none;
                 border-color: #2563eb;
                 box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
@@ -275,11 +277,15 @@ require_once __DIR__ . '/header.php';
                     <input type="hidden" name="productId" id="productId">
                     <label for="productName">
                         Ürün Adı
-                        <input type="text" id="productName" name="name" placeholder="Örn. Temperli Cam" required>
+                        <input type="text" id="productName" name="name" required>
                     </label>
                     <label for="productType">
                         Ürün Türü
-                        <input type="text" id="productType" name="type" placeholder="Örn. Cam Türü">
+                        <select id="productType" name="type">
+                            <option value="">Tür seçin</option>
+                            <option value="Isıcam">Isıcam</option>
+                            <option value="Tekcam">Tekcam</option>
+                        </select>
                     </label>
                     <div class="modal-actions">
                         <button type="button" class="cancel" id="cancelModal">Vazgeç</button>
@@ -390,6 +396,16 @@ require_once __DIR__ . '/header.php';
                     productIdField.value = product.id;
                     productNameField.value = product.name || '';
                     productTypeField.value = product.type || '';
+                    if (product.type && productTypeField.value !== product.type) {
+                        const hasOption = Array.from(productTypeField.options).some((option) => option.value === product.type);
+                        if (!hasOption) {
+                            const customOption = document.createElement('option');
+                            customOption.value = product.type;
+                            customOption.textContent = product.type;
+                            productTypeField.appendChild(customOption);
+                        }
+                        productTypeField.value = product.type;
+                    }
                     toggleModal(true);
                 }
 


### PR DESCRIPTION
## Summary
- add a suppliers.php dashboard page with responsive layout, modal editing, and client-side scripting to manage suppliers
- implement supplier add, edit, and delete API endpoints with authentication checks and JSON responses

## Testing
- php -l suppliers.php
- php -l api/supplier/add.php
- php -l api/supplier/edit.php
- php -l api/supplier/delete.php

------
https://chatgpt.com/codex/tasks/task_e_68db8493899083289e3cea1f7fe130fa