### PR TITLE
Add basic authentication pages and dashboard layout

### DIFF
--- a/cdn/bootstrap.php
+++ b/cdn/bootstrap.php
@@ -1,0 +1,4 @@
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js" integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y" crossorigin="anonymous"></script>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+if (isset($_GET['logout'])) {
+    session_unset();
+    session_destroy();
+    header('Location: login.php');
+    exit;
+}
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/sidebar.php';
+
+$userFullName = $_SESSION['fullname'] ?? '';
+$username = $_SESSION['username'] ?? '';
+
+try {
+    if ($userFullName === '' || $username === '') {
+        $statement = $pdo->prepare('SELECT firstname, lastname, username FROM users WHERE id = :id LIMIT 1');
+        $statement->execute(['id' => (int) $_SESSION['user_id']]);
+        $user = $statement->fetch();
+
+        if ($user) {
+            $userFullName = trim(($user['firstname'] ?? '') . ' ' . ($user['lastname'] ?? ''));
+            $username = $user['username'] ?? $username;
+            $_SESSION['fullname'] = $userFullName;
+            $_SESSION['username'] = $username;
+        }
+    }
+
+    $stats = [
+        'projects' => 0,
+        'orders' => 0,
+        'suppliers' => 0,
+    ];
+
+    $stats['projects'] = (int) $pdo->query('SELECT COUNT(*) FROM projects')->fetchColumn();
+    $stats['orders'] = (int) $pdo->query('SELECT COUNT(*) FROM orders')->fetchColumn();
+    $stats['suppliers'] = (int) $pdo->query('SELECT COUNT(*) FROM suppliers')->fetchColumn();
+} catch (PDOException $exception) {
+    $stats = [
+        'projects' => 0,
+        'orders' => 0,
+        'suppliers' => 0,
+    ];
+}
+
+$sidebarFonts = nexa_sidebar_fonts();
+$sidebarHtml = nexa_render_sidebar('dashboard.php');
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gösterge Paneli</title>
+    <?= $sidebarFonts; ?>
+    <?php include __DIR__ . '/cdn/bootstrap.php'; ?>
+    <style>
+        body {
+            background-color: #f8f9fa;
+        }
+        .sidebar-container {
+            width: 260px;
+        }
+        .welcome-title {
+            font-family: 'Monoton', cursive;
+            letter-spacing: 3px;
+        }
+    </style>
+</head>
+<body>
+    <div class="d-flex">
+        <div class="sidebar-container">
+            <?= $sidebarHtml; ?>
+        </div>
+        <main class="flex-grow-1 p-4">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+                <div>
+                    <h1 class="welcome-title text-primary mb-0">Nexa</h1>
+                    <p class="text-muted mb-0">Hoş geldiniz<?= $userFullName ? ', ' . htmlspecialchars($userFullName, ENT_QUOTES, 'UTF-8') : ''; ?>!</p>
+                    <?php if ($username): ?>
+                        <small class="text-secondary">Kullanıcı adınız: <?= htmlspecialchars($username, ENT_QUOTES, 'UTF-8'); ?></small>
+                    <?php endif; ?>
+                </div>
+                <a class="btn btn-outline-primary" href="?logout=1">Oturumu Kapat</a>
+            </div>
+
+            <section>
+                <h2 class="h4 mb-3">Özet Bilgiler</h2>
+                <div class="row g-4">
+                    <div class="col-md-4">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h3 class="h6 text-uppercase text-muted">Projeler</h3>
+                                <p class="display-6 fw-bold mb-0 text-primary"><?= number_format($stats['projects']); ?></p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h3 class="h6 text-uppercase text-muted">Siparişler</h3>
+                                <p class="display-6 fw-bold mb-0 text-success"><?= number_format($stats['orders']); ?></p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h3 class="h6 text-uppercase text-muted">Tedarikçiler</h3>
+                                <p class="display-6 fw-bold mb-0 text-danger"><?= number_format($stats['suppliers']); ?></p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/fonts/monoton.php
+++ b/fonts/monoton.php
@@ -1,0 +1,3 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Monoton&display=swap" rel="stylesheet">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+header('Location: login.php');
+exit;

--- a/login.php
+++ b/login.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+require_once __DIR__ . '/config.php';
+
+$identifier = '';
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $identifier = trim($_POST['identifier'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($identifier === '') {
+        $errors[] = 'Lütfen kullanıcı adı veya e-posta giriniz.';
+    }
+
+    if ($password === '') {
+        $errors[] = 'Lütfen şifrenizi giriniz.';
+    }
+
+    if (!$errors) {
+        try {
+            $statement = $pdo->prepare('SELECT id, firstname, lastname, username, password_hash FROM users WHERE username = :identifier OR email = :identifier LIMIT 1');
+            $statement->execute(['identifier' => $identifier]);
+            $user = $statement->fetch();
+
+            if ($user && password_verify($password, $user['password_hash'])) {
+                $_SESSION['user_id'] = (int) $user['id'];
+                $_SESSION['username'] = $user['username'];
+                $_SESSION['fullname'] = trim(($user['firstname'] ?? '') . ' ' . ($user['lastname'] ?? ''));
+
+                header('Location: dashboard.php');
+                exit;
+            }
+
+            $errors[] = 'Geçersiz kullanıcı adı/e-posta veya şifre.';
+        } catch (PDOException $exception) {
+            $errors[] = 'Giriş sırasında bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Giriş Yap</title>
+    <?php include __DIR__ . '/fonts/monoton.php'; ?>
+    <?php include __DIR__ . '/cdn/bootstrap.php'; ?>
+    <style>
+        body {
+            background: linear-gradient(135deg, #6610f2 0%, #d63384 100%);
+            min-height: 100vh;
+        }
+        .card {
+            border: none;
+            border-radius: 1rem;
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+        }
+        .brand-title {
+            font-family: 'Monoton', cursive;
+            letter-spacing: 4px;
+            font-size: 2rem;
+        }
+    </style>
+</head>
+<body class="d-flex align-items-center justify-content-center p-3">
+    <div class="card w-100" style="max-width: 420px;">
+        <div class="card-body p-5">
+            <h1 class="brand-title text-center text-primary mb-4">Nexa</h1>
+            <h2 class="text-center mb-4">Hesabınıza Giriş Yapın</h2>
+
+            <?php if ($errors): ?>
+                <div class="alert alert-danger" role="alert">
+                    <ul class="mb-0">
+                        <?php foreach ($errors as $error): ?>
+                            <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+
+            <form method="post" novalidate>
+                <div class="mb-3">
+                    <label for="identifier" class="form-label">Kullanıcı Adı veya E-posta</label>
+                    <input type="text" class="form-control" id="identifier" name="identifier" value="<?= htmlspecialchars($identifier, ENT_QUOTES, 'UTF-8'); ?>" required>
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">Şifre</label>
+                    <input type="password" class="form-control" id="password" name="password" required>
+                </div>
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-primary btn-lg">Giriş Yap</button>
+                </div>
+            </form>
+
+            <p class="mt-4 text-center mb-0">
+                Henüz hesabınız yok mu? <a href="register.php" class="link-primary fw-semibold">Kayıt Olun</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,177 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+require_once __DIR__ . '/config.php';
+
+$input = [
+    'firstname' => '',
+    'lastname' => '',
+    'email' => '',
+    'username' => '',
+];
+
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $input['firstname'] = trim($_POST['firstname'] ?? '');
+    $input['lastname'] = trim($_POST['lastname'] ?? '');
+    $input['email'] = trim($_POST['email'] ?? '');
+    $input['username'] = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $confirmPassword = $_POST['confirm_password'] ?? '';
+
+    if ($input['firstname'] === '') {
+        $errors[] = 'Lütfen adınızı giriniz.';
+    }
+
+    if ($input['lastname'] === '') {
+        $errors[] = 'Lütfen soyadınızı giriniz.';
+    }
+
+    if ($input['email'] === '' || !filter_var($input['email'], FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Geçerli bir e-posta adresi giriniz.';
+    }
+
+    if ($input['username'] === '' || !preg_match('/^[A-Za-z0-9_]{3,}$/', $input['username'])) {
+        $errors[] = 'Kullanıcı adı en az 3 karakter olmalı ve sadece harf, rakam ve alt çizgi içermelidir.';
+    }
+
+    if ($password === '' || strlen($password) < 8) {
+        $errors[] = 'Şifre en az 8 karakter olmalıdır.';
+    }
+
+    if ($password !== $confirmPassword) {
+        $errors[] = 'Şifre ve şifre tekrarı eşleşmiyor.';
+    }
+
+    if (!$errors) {
+        try {
+            $emailStatement = $pdo->prepare('SELECT COUNT(*) FROM users WHERE email = :email');
+            $emailStatement->execute(['email' => $input['email']]);
+
+            if ((int) $emailStatement->fetchColumn() > 0) {
+                $errors[] = 'Bu e-posta adresi zaten kayıtlı.';
+            }
+
+            $usernameStatement = $pdo->prepare('SELECT COUNT(*) FROM users WHERE username = :username');
+            $usernameStatement->execute(['username' => $input['username']]);
+
+            if ((int) $usernameStatement->fetchColumn() > 0) {
+                $errors[] = 'Bu kullanıcı adı zaten kullanılıyor.';
+            }
+
+            if (!$errors) {
+                $passwordHash = password_hash($password, PASSWORD_DEFAULT);
+
+                $insertStatement = $pdo->prepare(
+                    'INSERT INTO users (firstname, lastname, email, username, password_hash) VALUES (:firstname, :lastname, :email, :username, :password_hash)'
+                );
+
+                $insertStatement->execute([
+                    'firstname' => $input['firstname'],
+                    'lastname' => $input['lastname'],
+                    'email' => $input['email'],
+                    'username' => $input['username'],
+                    'password_hash' => $passwordHash,
+                ]);
+
+                $_SESSION['user_id'] = (int) $pdo->lastInsertId();
+                $_SESSION['username'] = $input['username'];
+                $_SESSION['fullname'] = $input['firstname'] . ' ' . $input['lastname'];
+
+                header('Location: dashboard.php');
+                exit;
+            }
+        } catch (PDOException $exception) {
+            $errors[] = 'Kayıt sırasında bir hata oluştu. Lütfen daha sonra tekrar deneyiniz.';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kayıt Ol</title>
+    <?php include __DIR__ . '/fonts/monoton.php'; ?>
+    <?php include __DIR__ . '/cdn/bootstrap.php'; ?>
+    <style>
+        body {
+            background: linear-gradient(135deg, #0d6efd 0%, #6610f2 100%);
+            min-height: 100vh;
+        }
+        .card {
+            border: none;
+            border-radius: 1rem;
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+        }
+        .brand-title {
+            font-family: 'Monoton', cursive;
+            letter-spacing: 4px;
+            font-size: 2rem;
+        }
+    </style>
+</head>
+<body class="d-flex align-items-center justify-content-center p-3">
+    <div class="card w-100" style="max-width: 480px;">
+        <div class="card-body p-5">
+            <h1 class="brand-title text-center text-primary mb-4">Nexa</h1>
+            <h2 class="text-center mb-4">Yeni Hesap Oluştur</h2>
+
+            <?php if ($errors): ?>
+                <div class="alert alert-danger" role="alert">
+                    <ul class="mb-0">
+                        <?php foreach ($errors as $error): ?>
+                            <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+
+            <form method="post" novalidate>
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label for="firstname" class="form-label">Ad</label>
+                        <input type="text" class="form-control" id="firstname" name="firstname" value="<?= htmlspecialchars($input['firstname'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                    </div>
+                    <div class="col-md-6">
+                        <label for="lastname" class="form-label">Soyad</label>
+                        <input type="text" class="form-control" id="lastname" name="lastname" value="<?= htmlspecialchars($input['lastname'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                    </div>
+                    <div class="col-12">
+                        <label for="email" class="form-label">E-posta</label>
+                        <input type="email" class="form-control" id="email" name="email" value="<?= htmlspecialchars($input['email'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                    </div>
+                    <div class="col-12">
+                        <label for="username" class="form-label">Kullanıcı Adı</label>
+                        <input type="text" class="form-control" id="username" name="username" value="<?= htmlspecialchars($input['username'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                    </div>
+                    <div class="col-12">
+                        <label for="password" class="form-label">Şifre</label>
+                        <input type="password" class="form-control" id="password" name="password" required minlength="8">
+                    </div>
+                    <div class="col-12">
+                        <label for="confirm_password" class="form-label">Şifre Tekrarı</label>
+                        <input type="password" class="form-control" id="confirm_password" name="confirm_password" required minlength="8">
+                    </div>
+                </div>
+                <div class="d-grid mt-4">
+                    <button type="submit" class="btn btn-primary btn-lg">Kayıt Ol</button>
+                </div>
+            </form>
+
+            <p class="mt-4 text-center mb-0">
+                Zaten hesabınız var mı? <a href="login.php" class="link-primary fw-semibold">Giriş Yapın</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Provides helper functions to render the Nexa sidebar navigation.
+ */
+if (!function_exists('nexa_sidebar_fonts')) {
+    /**
+     * Returns the font includes required by the sidebar.
+     */
+    function nexa_sidebar_fonts(): string
+    {
+        ob_start();
+        include __DIR__ . '/fonts/monoton.php';
+
+        return ob_get_clean() ?: '';
+    }
+}
+
+if (!function_exists('nexa_render_sidebar')) {
+    /**
+     * Renders the sidebar navigation HTML.
+     *
+     * @param string $active The filename of the active navigation item.
+     */
+    function nexa_render_sidebar(string $active = 'dashboard.php'): string
+    {
+        $navigation = [
+            'dashboard.php' => 'Gösterge Paneli',
+            'projects.php' => 'Projeler',
+            'orders.php' => 'Siparişler',
+            'suppliers.php' => 'Tedarikçiler',
+        ];
+
+        $html = '<nav class="d-flex flex-column flex-grow-1 gap-2 p-4 bg-dark text-white" style="min-height:100vh;">';
+        $html .= '<div class="mb-4"><span class="fs-4" style="font-family: \'Monoton\', cursive; letter-spacing: 4px;">Nexa</span></div>';
+
+        foreach ($navigation as $file => $label) {
+            $isActive = $file === $active;
+            $classes = 'btn btn-sm text-start ' . ($isActive ? 'btn-primary' : 'btn-outline-light');
+            $html .= sprintf(
+                '<a class="%s" href="%s">%s</a>',
+                htmlspecialchars($classes, ENT_QUOTES, 'UTF-8'),
+                htmlspecialchars($file, ENT_QUOTES, 'UTF-8'),
+                htmlspecialchars($label, ENT_QUOTES, 'UTF-8')
+            );
+        }
+
+        $html .= '<div class="mt-auto pt-4 border-top border-secondary">';
+        $html .= '<a class="btn btn-outline-light w-100" href="?logout=1">Çıkış Yap</a>';
+        $html .= '</div>';
+        $html .= '</nav>';
+
+        return $html;
+    }
+}


### PR DESCRIPTION
## Summary
- add shared Monoton font include and Bootstrap CDN snippet
- implement registration and login pages backed by the existing database connection
- introduce dashboard, sidebar helper, and index redirect to handle authenticated navigation

## Testing
- php -l register.php
- php -l login.php
- php -l dashboard.php
- php -l sidebar.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68db94a3ec008328811daa74d50ab741