### PR TITLE
Add authentication pages and dashboard layout

### DIFF
--- a/cdn/bootstrap.php
+++ b/cdn/bootstrap.php
@@ -1,0 +1,4 @@
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js" integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y" crossorigin="anonymous"></script>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,109 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$userFullName = trim(($_SESSION['firstname'] ?? '') . ' ' . ($_SESSION['lastname'] ?? ''));
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kontrol Paneli</title>
+    <?php include __DIR__ . '/fonts/monoton.php'; ?>
+    <?php include __DIR__ . '/cdn/bootstrap.php'; ?>
+    <style>
+        body {
+            background-color: #f1f3f5;
+            font-family: 'Inter', sans-serif;
+        }
+
+        .dashboard-wrapper {
+            display: grid;
+            grid-template-columns: 280px 1fr;
+            min-height: 100vh;
+        }
+
+        .content-area {
+            padding: 2rem;
+        }
+
+        @media (max-width: 992px) {
+            .dashboard-wrapper {
+                grid-template-columns: 1fr;
+            }
+
+            .content-area {
+                padding: 1.5rem 1rem 3rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="dashboard-wrapper">
+        <?php include __DIR__ . '/sidebar.php'; ?>
+        <main class="content-area">
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
+                <div>
+                    <h1 class="h3 fw-bold">Merhaba, <?= htmlspecialchars($userFullName !== '' ? $userFullName : ($_SESSION['username'] ?? 'Kullanıcı'), ENT_QUOTES, 'UTF-8') ?>!</h1>
+                    <p class="text-muted mb-0">Bugünkü özetinizi aşağıda bulabilirsiniz.</p>
+                </div>
+                <a href="logout.php" class="btn btn-outline-danger">Çıkış yap</a>
+            </div>
+            <div class="row g-4">
+                <div class="col-md-4">
+                    <div class="card border-0 shadow-sm h-100">
+                        <div class="card-body">
+                            <h2 class="h6 text-uppercase text-muted">Aktif Projeler</h2>
+                            <p class="display-6 fw-bold mb-0">5</p>
+                            <small class="text-success">+2 yeni proje</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card border-0 shadow-sm h-100">
+                        <div class="card-body">
+                            <h2 class="h6 text-uppercase text-muted">Aylık Siparişler</h2>
+                            <p class="display-6 fw-bold mb-0">32</p>
+                            <small class="text-primary">%8 artış</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card border-0 shadow-sm h-100">
+                        <div class="card-body">
+                            <h2 class="h6 text-uppercase text-muted">Tedarikçi Güncellemeleri</h2>
+                            <p class="display-6 fw-bold mb-0">7</p>
+                            <small class="text-warning">3 beklemede</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card border-0 shadow-sm mt-4">
+                <div class="card-body">
+                    <h2 class="h5 fw-bold">Hızlı Erişim</h2>
+                    <p class="text-muted">Sık kullanılan araçlarınıza buradan ulaşabilirsiniz.</p>
+                    <div class="row g-3">
+                        <div class="col-sm-6 col-lg-3">
+                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Yeni Sipariş</a>
+                        </div>
+                        <div class="col-sm-6 col-lg-3">
+                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Proje Oluştur</a>
+                        </div>
+                        <div class="col-sm-6 col-lg-3">
+                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Fiyat Listesi</a>
+                        </div>
+                        <div class="col-sm-6 col-lg-3">
+                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Tedarikçi Ekle</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/dashboard.php
+++ b/dashboard.php
@@ -6,7 +6,64 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+require_once __DIR__ . '/config.php';
+
 $userFullName = trim(($_SESSION['firstname'] ?? '') . ' ' . ($_SESSION['lastname'] ?? ''));
+
+/**
+ * @param PDO   $pdo
+ * @param string $sql
+ * @param array<int|string, mixed> $params
+ */
+function fetchCount(PDO $pdo, string $sql, array $params = []): ?int
+{
+    try {
+        $statement = $pdo->prepare($sql);
+        $statement->execute($params);
+
+        $value = $statement->fetchColumn();
+
+        return $value !== false ? (int) $value : null;
+    } catch (Throwable $exception) {
+        error_log('Dashboard metric query failed: ' . $exception->getMessage());
+
+        return null;
+    }
+}
+
+$dashboardMetrics = [
+    [
+        'label' => 'Toplam Proje',
+        'value' => fetchCount(
+            $pdo,
+            'SELECT COUNT(*) FROM projects'
+        ),
+        'description' => 'Kayıtlı proje sayısı',
+    ],
+    [
+        'label' => 'Aylık Siparişler',
+        'value' => fetchCount(
+            $pdo,
+            'SELECT COUNT(*) FROM orders WHERE YEAR(order_date) = YEAR(CURRENT_DATE()) AND MONTH(order_date) = MONTH(CURRENT_DATE())'
+        ),
+        'description' => 'Bu ay oluşturulan siparişler',
+    ],
+    [
+        'label' => 'Aktif Tedarikçiler',
+        'value' => fetchCount(
+            $pdo,
+            'SELECT COUNT(*) FROM suppliers'
+        ),
+        'description' => 'Kayıtlı tedarikçi sayısı',
+    ],
+];
+
+$quickActions = [
+    ['label' => 'Yeni Sipariş', 'href' => '#'],
+    ['label' => 'Proje Oluştur', 'href' => '#'],
+    ['label' => 'Fiyat Listesi', 'href' => '#'],
+    ['label' => 'Tedarikçi Ekle', 'href' => '#'],
+];
 ?>
 <!DOCTYPE html>
 <html lang="tr">
@@ -55,51 +112,32 @@ $userFullName = trim(($_SESSION['firstname'] ?? '') . ' ' . ($_SESSION['lastname
                 <a href="logout.php" class="btn btn-outline-danger">Çıkış yap</a>
             </div>
             <div class="row g-4">
-                <div class="col-md-4">
-                    <div class="card border-0 shadow-sm h-100">
-                        <div class="card-body">
-                            <h2 class="h6 text-uppercase text-muted">Aktif Projeler</h2>
-                            <p class="display-6 fw-bold mb-0">5</p>
-                            <small class="text-success">+2 yeni proje</small>
+                <?php foreach ($dashboardMetrics as $metric): ?>
+                    <div class="col-md-4">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h2 class="h6 text-uppercase text-muted"><?= htmlspecialchars($metric['label'], ENT_QUOTES, 'UTF-8'); ?></h2>
+                                <p class="display-6 fw-bold mb-0">
+                                    <?= $metric['value'] !== null ? number_format($metric['value'], 0, ',', '.') : '—'; ?>
+                                </p>
+                                <small class="text-muted"><?= htmlspecialchars($metric['description'], ENT_QUOTES, 'UTF-8'); ?></small>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="col-md-4">
-                    <div class="card border-0 shadow-sm h-100">
-                        <div class="card-body">
-                            <h2 class="h6 text-uppercase text-muted">Aylık Siparişler</h2>
-                            <p class="display-6 fw-bold mb-0">32</p>
-                            <small class="text-primary">%8 artış</small>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-4">
-                    <div class="card border-0 shadow-sm h-100">
-                        <div class="card-body">
-                            <h2 class="h6 text-uppercase text-muted">Tedarikçi Güncellemeleri</h2>
-                            <p class="display-6 fw-bold mb-0">7</p>
-                            <small class="text-warning">3 beklemede</small>
-                        </div>
-                    </div>
-                </div>
+                <?php endforeach; ?>
             </div>
             <div class="card border-0 shadow-sm mt-4">
                 <div class="card-body">
                     <h2 class="h5 fw-bold">Hızlı Erişim</h2>
                     <p class="text-muted">Sık kullanılan araçlarınıza buradan ulaşabilirsiniz.</p>
                     <div class="row g-3">
-                        <div class="col-sm-6 col-lg-3">
-                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Yeni Sipariş</a>
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Proje Oluştur</a>
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Fiyat Listesi</a>
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <a href="#" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">Tedarikçi Ekle</a>
-                        </div>
+                        <?php foreach ($quickActions as $action): ?>
+                            <div class="col-sm-6 col-lg-3">
+                                <a href="<?= htmlspecialchars($action['href'], ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-light w-100 py-3 border rounded-3 shadow-sm">
+                                    <?= htmlspecialchars($action['label'], ENT_QUOTES, 'UTF-8'); ?>
+                                </a>
+                            </div>
+                        <?php endforeach; ?>
                     </div>
                 </div>
             </div>

--- a/fonts/monoton.php
+++ b/fonts/monoton.php
@@ -1,0 +1,3 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Monoton&display=swap" rel="stylesheet">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,10 @@
+<?php
+session_start();
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+header('Location: login.php');
+exit;

--- a/login.php
+++ b/login.php
@@ -24,8 +24,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     if (!$errors) {
-        $statement = $pdo->prepare('SELECT id, firstname, lastname, username, password_hash FROM users WHERE email = :identifier OR username = :identifier LIMIT 1');
-        $statement->execute([':identifier' => $usernameOrEmail]);
+        $statement = $pdo->prepare(
+            'SELECT id, firstname, lastname, username, password_hash FROM users WHERE email = :email_identifier OR username = :username_identifier LIMIT 1'
+        );
+        $statement->execute([
+            ':email_identifier' => $usernameOrEmail,
+            ':username_identifier' => $usernameOrEmail,
+        ]);
         $user = $statement->fetch();
 
         if (!$user || !password_verify($password, $user['password_hash'])) {

--- a/login.php
+++ b/login.php
@@ -1,0 +1,127 @@
+<?php
+session_start();
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+require __DIR__ . '/config.php';
+
+$errors = [];
+$usernameOrEmail = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $usernameOrEmail = trim($_POST['username_or_email'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($usernameOrEmail === '') {
+        $errors['username_or_email'] = 'Lütfen kullanıcı adı veya e-postanızı girin.';
+    }
+
+    if ($password === '') {
+        $errors['password'] = 'Lütfen şifrenizi girin.';
+    }
+
+    if (!$errors) {
+        $statement = $pdo->prepare('SELECT id, firstname, lastname, username, password_hash FROM users WHERE email = :identifier OR username = :identifier LIMIT 1');
+        $statement->execute([':identifier' => $usernameOrEmail]);
+        $user = $statement->fetch();
+
+        if (!$user || !password_verify($password, $user['password_hash'])) {
+            $errors['credentials'] = 'Kullanıcı adı/e-posta veya şifre hatalı.';
+        } else {
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['firstname'] = $user['firstname'];
+            $_SESSION['lastname'] = $user['lastname'];
+            $_SESSION['username'] = $user['username'];
+
+            header('Location: dashboard.php');
+            exit;
+        }
+    }
+}
+
+$registered = isset($_GET['registered']);
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Giriş Yap</title>
+    <?php include __DIR__ . '/fonts/monoton.php'; ?>
+    <?php include __DIR__ . '/cdn/bootstrap.php'; ?>
+    <style>
+        body {
+            background: linear-gradient(135deg, #6610f2, #d63384);
+            min-height: 100vh;
+            font-family: 'Inter', sans-serif;
+        }
+
+        .brand-title {
+            font-family: 'Monoton', cursive;
+            letter-spacing: 6px;
+        }
+
+        .card {
+            border: none;
+            border-radius: 1rem;
+            box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.15);
+        }
+    </style>
+</head>
+<body class="d-flex align-items-center justify-content-center py-5">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-4 col-md-6">
+                <div class="card p-4 p-md-5">
+                    <div class="text-center mb-4">
+                        <h1 class="brand-title display-5 text-primary">NEXA</h1>
+                        <p class="text-muted">Hesabınıza giriş yapın</p>
+                    </div>
+                    <?php if ($registered): ?>
+                        <div class="alert alert-success">
+                            Kayıt işlemi başarılı! Şimdi giriş yapabilirsiniz.
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($errors): ?>
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                <?php foreach ($errors as $error): ?>
+                                    <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                    <?php endif; ?>
+                    <form method="post" novalidate>
+                        <div class="mb-3">
+                            <label class="form-label" for="username_or_email">Kullanıcı Adı veya E-posta</label>
+                            <input type="text" class="form-control" id="username_or_email" name="username_or_email" value="<?= htmlspecialchars($usernameOrEmail, ENT_QUOTES, 'UTF-8') ?>" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="password">Şifre</label>
+                            <input type="password" class="form-control" id="password" name="password" required>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="1" id="remember" disabled>
+                                <label class="form-check-label" for="remember">
+                                    Beni hatırla (yakında)
+                                </label>
+                            </div>
+                            <a href="#" class="text-decoration-none disabled" tabindex="-1" aria-disabled="true">Şifremi unuttum?</a>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary btn-lg">Giriş Yap</button>
+                        </div>
+                    </form>
+                    <p class="mt-4 text-center mb-0">
+                        Henüz hesabınız yok mu? <a href="register.php">Kayıt olun</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+
+$_SESSION = [];
+
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+}
+
+session_destroy();
+
+header('Location: login.php');
+exit;

--- a/register.php
+++ b/register.php
@@ -1,0 +1,162 @@
+<?php
+session_start();
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+require __DIR__ . '/config.php';
+
+$errors = [];
+$values = [
+    'firstname' => '',
+    'lastname' => '',
+    'email' => '',
+    'username' => '',
+];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $values['firstname'] = trim($_POST['firstname'] ?? '');
+    $values['lastname'] = trim($_POST['lastname'] ?? '');
+    $values['email'] = trim($_POST['email'] ?? '');
+    $values['username'] = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $passwordConfirm = $_POST['password_confirm'] ?? '';
+
+    if ($values['firstname'] === '') {
+        $errors['firstname'] = 'Lütfen adınızı girin.';
+    }
+
+    if ($values['lastname'] === '') {
+        $errors['lastname'] = 'Lütfen soyadınızı girin.';
+    }
+
+    if ($values['email'] === '' || !filter_var($values['email'], FILTER_VALIDATE_EMAIL)) {
+        $errors['email'] = 'Geçerli bir e-posta adresi girin.';
+    }
+
+    if ($values['username'] === '' || !preg_match('/^[A-Za-z0-9_\.\-]{3,50}$/', $values['username'])) {
+        $errors['username'] = 'Kullanıcı adı en az 3 karakter olmalı ve sadece harf, rakam, nokta, tire veya alt tire içermelidir.';
+    }
+
+    if ($password === '' || strlen($password) < 8) {
+        $errors['password'] = 'Şifre en az 8 karakter olmalıdır.';
+    }
+
+    if ($password !== $passwordConfirm) {
+        $errors['password_confirm'] = 'Şifreler eşleşmiyor.';
+    }
+
+    if (!$errors) {
+        $checkStatement = $pdo->prepare('SELECT id FROM users WHERE email = :email OR username = :username LIMIT 1');
+        $checkStatement->execute([
+            ':email' => $values['email'],
+            ':username' => $values['username'],
+        ]);
+
+        if ($checkStatement->fetch()) {
+            $errors['duplicate'] = 'Bu e-posta veya kullanıcı adı zaten kullanılıyor.';
+        }
+    }
+
+    if (!$errors) {
+        $insertStatement = $pdo->prepare('INSERT INTO users (firstname, lastname, email, username, password_hash) VALUES (:firstname, :lastname, :email, :username, :password_hash)');
+        $insertStatement->execute([
+            ':firstname' => $values['firstname'],
+            ':lastname' => $values['lastname'],
+            ':email' => $values['email'],
+            ':username' => $values['username'],
+            ':password_hash' => password_hash($password, PASSWORD_DEFAULT),
+        ]);
+
+        header('Location: login.php?registered=1');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kayıt Ol</title>
+    <?php include __DIR__ . '/fonts/monoton.php'; ?>
+    <?php include __DIR__ . '/cdn/bootstrap.php'; ?>
+    <style>
+        body {
+            background: linear-gradient(135deg, #0d6efd, #6610f2);
+            min-height: 100vh;
+            font-family: 'Inter', sans-serif;
+        }
+
+        .brand-title {
+            font-family: 'Monoton', cursive;
+            letter-spacing: 6px;
+        }
+
+        .card {
+            border: none;
+            border-radius: 1rem;
+            box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.15);
+        }
+    </style>
+</head>
+<body class="d-flex align-items-center justify-content-center py-5">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-5 col-md-7">
+                <div class="card p-4 p-md-5">
+                    <div class="text-center mb-4">
+                        <h1 class="brand-title display-5 text-primary">NEXA</h1>
+                        <p class="text-muted">Yeni hesabınızı oluşturun</p>
+                    </div>
+                    <?php if ($errors): ?>
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                <?php foreach ($errors as $error): ?>
+                                    <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                    <?php endif; ?>
+                    <form method="post" novalidate>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label" for="firstname">Ad</label>
+                                <input type="text" class="form-control" id="firstname" name="firstname" value="<?= htmlspecialchars($values['firstname'], ENT_QUOTES, 'UTF-8') ?>" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="lastname">Soyad</label>
+                                <input type="text" class="form-control" id="lastname" name="lastname" value="<?= htmlspecialchars($values['lastname'], ENT_QUOTES, 'UTF-8') ?>" required>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label" for="email">E-posta</label>
+                                <input type="email" class="form-control" id="email" name="email" value="<?= htmlspecialchars($values['email'], ENT_QUOTES, 'UTF-8') ?>" required>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label" for="username">Kullanıcı Adı</label>
+                                <input type="text" class="form-control" id="username" name="username" value="<?= htmlspecialchars($values['username'], ENT_QUOTES, 'UTF-8') ?>" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="password">Şifre</label>
+                                <input type="password" class="form-control" id="password" name="password" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="password_confirm">Şifre (Tekrar)</label>
+                                <input type="password" class="form-control" id="password_confirm" name="password_confirm" required>
+                            </div>
+                        </div>
+                        <div class="d-grid gap-2 mt-4">
+                            <button type="submit" class="btn btn-primary btn-lg">Kayıt Ol</button>
+                        </div>
+                    </form>
+                    <p class="mt-4 text-center mb-0">
+                        Zaten hesabınız var mı? <a href="login.php">Giriş yapın</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/sidebar.php
+++ b/sidebar.php
@@ -8,6 +8,11 @@ if (!defined('MONOTON_FONT_INCLUDED')) {
     define('MONOTON_FONT_INCLUDED', true);
 }
 
+if (!defined('BOOTSTRAP_CDN_INCLUDED')) {
+    include __DIR__ . '/cdn/bootstrap.php';
+    define('BOOTSTRAP_CDN_INCLUDED', true);
+}
+
 if (!defined('BOOTSTRAP_ICONS_INCLUDED')) {
     echo '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">';
     define('BOOTSTRAP_ICONS_INCLUDED', true);

--- a/sidebar.php
+++ b/sidebar.php
@@ -118,6 +118,7 @@ $username = $_SESSION['username'] ?? 'kullanici';
         width: 100%;
         max-width: 280px;
         position: relative;
+        font-size: 0.95rem;
     }
 
     .profile-avatar {
@@ -127,11 +128,25 @@ $username = $_SESSION['username'] ?? 'kullanici';
         font-size: 1.5rem;
     }
 
+    .sidebar-header p {
+        font-size: 0.85rem;
+    }
+
+    .nav-group h2 {
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+    }
+
+    .profile-section .fw-semibold {
+        font-size: 0.95rem;
+    }
+
     .nav-link {
         color: #343a40;
         padding: 0.75rem 1rem;
         border-radius: 0.75rem;
         transition: background-color 0.2s ease, color 0.2s ease;
+        font-size: 0.9rem;
     }
 
     .nav-link:hover,
@@ -158,7 +173,7 @@ $username = $_SESSION['username'] ?? 'kullanici';
 
     .submenu .nav-link {
         padding-left: 0.5rem;
-        font-size: 0.95rem;
+        font-size: 0.85rem;
     }
 
     .submenu-toggle {
@@ -167,6 +182,7 @@ $username = $_SESSION['username'] ?? 'kullanici';
         padding: 0.75rem 1rem;
         text-align: left;
         color: #343a40;
+        font-size: 0.9rem;
     }
 
     .submenu-toggle:hover,

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,0 +1,184 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!defined('MONOTON_FONT_INCLUDED')) {
+    include __DIR__ . '/fonts/monoton.php';
+    define('MONOTON_FONT_INCLUDED', true);
+}
+
+if (!defined('BOOTSTRAP_ICONS_INCLUDED')) {
+    echo '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">';
+    define('BOOTSTRAP_ICONS_INCLUDED', true);
+}
+
+$fullName = trim(($_SESSION['firstname'] ?? '') . ' ' . ($_SESSION['lastname'] ?? ''));
+$username = $_SESSION['username'] ?? 'kullanici';
+?>
+<aside class="sidebar bg-white border-end shadow-sm">
+    <div class="sidebar-header p-4 border-bottom text-center">
+        <h1 class="fs-2 mb-0" style="font-family: 'Monoton', cursive; letter-spacing: 4px;">NEXA</h1>
+        <p class="text-muted mb-0">Yönetim Paneli</p>
+    </div>
+    <div class="profile-section d-flex align-items-center gap-3 p-4 border-bottom">
+        <div class="profile-avatar d-flex align-items-center justify-content-center rounded-circle text-white fw-bold">
+            <?= htmlspecialchars(strtoupper(mb_substr($fullName !== '' ? $fullName : $username, 0, 1, 'UTF-8')), ENT_QUOTES, 'UTF-8') ?>
+        </div>
+        <div class="flex-grow-1">
+            <div class="fw-semibold text-dark">
+                <?= htmlspecialchars($fullName !== '' ? $fullName : 'Ad Soyad', ENT_QUOTES, 'UTF-8') ?>
+            </div>
+            <div class="text-muted small">@<?= htmlspecialchars($username, ENT_QUOTES, 'UTF-8') ?></div>
+        </div>
+        <div class="dropdown">
+            <button class="btn btn-link text-decoration-none text-dark p-0" type="button" id="profileMenu" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-three-dots-vertical"></i>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileMenu">
+                <li><a class="dropdown-item" href="#">Ayarlar</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item text-danger" href="logout.php">Çıkış yap</a></li>
+            </ul>
+        </div>
+    </div>
+    <nav class="sidebar-nav p-4">
+        <div class="nav-group mb-4">
+            <h2 class="text-uppercase text-muted fs-6 fw-semibold mb-3">Genel</h2>
+            <a href="dashboard.php" class="nav-link d-flex align-items-center gap-2 mb-2">
+                <span class="icon-circle"><i class="bi bi-house-door"></i></span>
+                <span>Anasayfa</span>
+            </a>
+        </div>
+        <div class="nav-group mb-4">
+            <h2 class="text-uppercase text-muted fs-6 fw-semibold mb-3">Katalog</h2>
+            <div class="submenu">
+                <button class="submenu-toggle nav-link d-flex w-100 align-items-center justify-content-between" data-bs-toggle="collapse" data-bs-target="#urunlerSubmenu" aria-expanded="true">
+                    <span class="d-flex align-items-center gap-2"><span class="icon-circle"><i class="bi bi-box"></i></span>Ürünler</span>
+                    <i class="bi bi-chevron-down"></i>
+                </button>
+                <div class="collapse show" id="urunlerSubmenu">
+                    <a href="#" class="nav-link ms-4">Ürün Listesi</a>
+                    <a href="#" class="nav-link ms-4">Yeni Ürün</a>
+                </div>
+            </div>
+            <div class="submenu mt-3">
+                <button class="submenu-toggle nav-link d-flex w-100 align-items-center justify-content-between" data-bs-toggle="collapse" data-bs-target="#tedarikcilerSubmenu" aria-expanded="false">
+                    <span class="d-flex align-items-center gap-2"><span class="icon-circle"><i class="bi bi-people"></i></span>Tedarikçiler</span>
+                    <i class="bi bi-chevron-down"></i>
+                </button>
+                <div class="collapse" id="tedarikcilerSubmenu">
+                    <a href="#" class="nav-link ms-4">Tedarikçi Listesi</a>
+                    <a href="#" class="nav-link ms-4">Tedarikçi Davet Et</a>
+                </div>
+            </div>
+        </div>
+        <div class="nav-group mb-4">
+            <h2 class="text-uppercase text-muted fs-6 fw-semibold mb-3">Finans</h2>
+            <div class="submenu">
+                <button class="submenu-toggle nav-link d-flex w-100 align-items-center justify-content-between" data-bs-toggle="collapse" data-bs-target="#fiyatlarSubmenu" aria-expanded="false">
+                    <span class="d-flex align-items-center gap-2"><span class="icon-circle"><i class="bi bi-cash"></i></span>Fiyatlar</span>
+                    <i class="bi bi-chevron-down"></i>
+                </button>
+                <div class="collapse" id="fiyatlarSubmenu">
+                    <a href="#" class="nav-link ms-4">Fiyat Listesi</a>
+                    <a href="#" class="nav-link ms-4">Fiyat Karşılaştırma</a>
+                </div>
+            </div>
+        </div>
+        <div class="nav-group">
+            <h2 class="text-uppercase text-muted fs-6 fw-semibold mb-3">Operasyon</h2>
+            <div class="submenu mb-3">
+                <button class="submenu-toggle nav-link d-flex w-100 align-items-center justify-content-between" data-bs-toggle="collapse" data-bs-target="#projelerSubmenu" aria-expanded="false">
+                    <span class="d-flex align-items-center gap-2"><span class="icon-circle"><i class="bi bi-kanban"></i></span>Projeler</span>
+                    <i class="bi bi-chevron-down"></i>
+                </button>
+                <div class="collapse" id="projelerSubmenu">
+                    <a href="#" class="nav-link ms-4">Proje Panosu</a>
+                    <a href="#" class="nav-link ms-4">Yeni Proje</a>
+                </div>
+            </div>
+            <div class="submenu">
+                <button class="submenu-toggle nav-link d-flex w-100 align-items-center justify-content-between" data-bs-toggle="collapse" data-bs-target="#siparislerSubmenu" aria-expanded="false">
+                    <span class="d-flex align-items-center gap-2"><span class="icon-circle"><i class="bi bi-clipboard-data"></i></span>Siparişler</span>
+                    <i class="bi bi-chevron-down"></i>
+                </button>
+                <div class="collapse" id="siparislerSubmenu">
+                    <a href="#" class="nav-link ms-4">Sipariş Takibi</a>
+                    <a href="#" class="nav-link ms-4">Yeni Sipariş</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+</aside>
+
+<style>
+    .sidebar {
+        min-height: 100vh;
+        width: 100%;
+        max-width: 280px;
+        position: relative;
+    }
+
+    .profile-avatar {
+        width: 56px;
+        height: 56px;
+        background: linear-gradient(135deg, #0d6efd, #6610f2);
+        font-size: 1.5rem;
+    }
+
+    .nav-link {
+        color: #343a40;
+        padding: 0.75rem 1rem;
+        border-radius: 0.75rem;
+        transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus {
+        background-color: rgba(13, 110, 253, 0.1);
+        color: #0d6efd;
+    }
+
+    .nav-link.active {
+        background-color: #0d6efd;
+        color: #fff;
+    }
+
+    .icon-circle {
+        display: inline-flex;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        align-items: center;
+        justify-content: center;
+        background-color: rgba(13, 110, 253, 0.1);
+        color: #0d6efd;
+    }
+
+    .submenu .nav-link {
+        padding-left: 0.5rem;
+        font-size: 0.95rem;
+    }
+
+    .submenu-toggle {
+        background: transparent;
+        border: none;
+        padding: 0.75rem 1rem;
+        text-align: left;
+        color: #343a40;
+    }
+
+    .submenu-toggle:hover,
+    .submenu-toggle:focus {
+        background-color: rgba(13, 110, 253, 0.08);
+        color: #0d6efd;
+    }
+
+    @media (max-width: 992px) {
+        .sidebar {
+            max-width: 100%;
+            border-right: none;
+        }
+    }
+</style>


### PR DESCRIPTION
## Summary
- add shared Monoton font and Bootstrap CDN includes for reuse
- implement registration, login, logout, and session-based redirects
- create dashboard layout with sidebar navigation and profile menu

## Testing
- php -l register.php
- php -l login.php
- php -l logout.php
- php -l dashboard.php
- php -l sidebar.php
- php -l index.php
- php -l fonts/monoton.php
- php -l cdn/bootstrap.php

------
https://chatgpt.com/codex/tasks/task_e_68db95c6da608328bab7b5acf4670985