### PR TITLE
Add server-side authentication handling to login page

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,5 +1,76 @@
 <?php
 // Login page for Nexa platform
+
+declare(strict_types=1);
+
+session_start();
+
+if (!empty($_SESSION['user']) || !empty($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+require __DIR__ . '/config.php';
+
+$errors = [];
+$generalError = '';
+$formData = [
+    'email' => '',
+    'remember' => false,
+];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $formData['email'] = trim((string)($_POST['email'] ?? ''));
+    $formData['remember'] = isset($_POST['remember']);
+    $password = (string)($_POST['password'] ?? '');
+
+    if ($formData['email'] === '') {
+        $errors['email'] = 'E-posta alanı zorunludur.';
+    } elseif (!filter_var($formData['email'], FILTER_VALIDATE_EMAIL)) {
+        $errors['email'] = 'Geçerli bir e-posta adresi girin.';
+    }
+
+    if ($password === '') {
+        $errors['password'] = 'Şifre alanı zorunludur.';
+    }
+
+    if (!$errors) {
+        $userQuery = $pdo->prepare(
+            'SELECT id, firstname, lastname, email, username, password_hash FROM users WHERE email = :email LIMIT 1'
+        );
+        $userQuery->execute(['email' => $formData['email']]);
+        $user = $userQuery->fetch();
+
+        if ($user && password_verify($password, (string)$user['password_hash'])) {
+            $_SESSION['user_id'] = (int)$user['id'];
+            $_SESSION['user'] = [
+                'id' => (int)$user['id'],
+                'firstname' => (string)$user['firstname'],
+                'lastname' => (string)$user['lastname'],
+                'email' => (string)$user['email'],
+                'username' => (string)$user['username'],
+            ];
+
+            if (!empty($_SESSION['flash'])) {
+                $_SESSION['flash'] = (array)$_SESSION['flash'];
+            } else {
+                $_SESSION['flash'] = [];
+            }
+
+            $_SESSION['flash'][] = 'Başarıyla giriş yaptınız.';
+
+            header('Location: dashboard.php');
+            exit;
+        }
+
+        $generalError = 'E-posta veya şifre hatalı.';
+    }
+}
+
+function e(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
 ?>
 <!DOCTYPE html>
 <html lang="tr">
@@ -113,24 +184,53 @@
         .form-options a {
             font-size: var(--font-size-sm);
         }
+
+        .alert {
+            border-radius: var(--radius-md);
+            padding: var(--spacing-sm) var(--spacing-md);
+            margin-bottom: var(--spacing-lg);
+            font-size: var(--font-size-sm);
+        }
+
+        .alert-error {
+            background-color: rgba(239, 68, 68, 0.1);
+            color: #b91c1c;
+            border: 1px solid rgba(239, 68, 68, 0.3);
+        }
+
+        .field-error {
+            color: #b91c1c;
+            font-size: var(--font-size-sm);
+        }
     </style>
 </head>
 <body>
     <main class="auth-card" role="main">
         <h1 class="auth-title">Nexa</h1>
         <p class="auth-subtitle">Hesabınıza giriş yapın</p>
-        <form action="#" method="post" novalidate>
+        <?php if ($generalError !== ''): ?>
+            <div class="alert alert-error" role="alert">
+                <?php echo e($generalError); ?>
+            </div>
+        <?php endif; ?>
+        <form action="" method="post" novalidate>
             <div class="form-group">
                 <label for="email">E-posta</label>
-                <input type="email" name="email" id="email" placeholder="ornek@nexa.com" required>
+                <input type="email" name="email" id="email" placeholder="ornek@nexa.com" value="<?php echo e($formData['email']); ?>" required>
+                <?php if (isset($errors['email'])): ?>
+                    <p class="field-error"><?php echo e($errors['email']); ?></p>
+                <?php endif; ?>
             </div>
             <div class="form-group">
                 <label for="password">Şifre</label>
                 <input type="password" name="password" id="password" placeholder="Şifrenizi girin" required>
+                <?php if (isset($errors['password'])): ?>
+                    <p class="field-error"><?php echo e($errors['password']); ?></p>
+                <?php endif; ?>
             </div>
             <div class="form-options">
                 <label>
-                    <input type="checkbox" name="remember" value="1">
+                    <input type="checkbox" name="remember" value="1" <?php echo $formData['remember'] ? 'checked' : ''; ?>>
                     Beni hatırla
                 </label>
                 <a href="#">Şifremi unuttum</a>


### PR DESCRIPTION
## Summary
- add session handling and database-backed authentication to the login page
- validate submitted credentials and set user session/flash messages after successful login
- surface validation and authentication errors within the login form UI

## Testing
- php -l login.php

------
https://chatgpt.com/codex/tasks/task_e_68dbaf93c25483288676115a5025c97a