### PR TITLE
Add toggle button to show or hide sidebar

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -41,10 +41,13 @@ if ($sidebarStyles !== '') {
 }
 
 $sidebarMarkup = $sidebarData['body'];
+$sidebarScripts = '';
 
 if ($sidebarMarkup !== '') {
-    if (preg_match('/<script\b[^>]*>.*?<\/script>/si', $sidebarMarkup, $scriptMatches)) {
-        $sidebarMarkup = trim(str_replace($scriptMatches[0], '', $sidebarMarkup));
+    $scriptMatches = [];
+    if (preg_match_all('/<script\b[^>]*>.*?<\/script>/si', $sidebarMarkup, $scriptMatches)) {
+        $sidebarScripts = trim(implode("\n", $scriptMatches[0]));
+        $sidebarMarkup = trim(preg_replace('/<script\b[^>]*>.*?<\/script>/si', '', $sidebarMarkup));
     }
 }
 
@@ -239,6 +242,9 @@ if (!empty($_SESSION['flash']) && is_array($_SESSION['flash'])) {
             </section>
         </main>
     </div>
+    <?php if ($sidebarScripts !== ''): ?>
+        <?= $sidebarScripts ?>
+    <?php endif; ?>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const dropdownToggle = document.querySelector('.dropdown-toggle');

--- a/sidebar.php
+++ b/sidebar.php
@@ -170,6 +170,39 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
             transform: translateY(-1px);
         }
 
+        .sidebar-toggle-icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.5rem;
+            line-height: 1;
+            min-width: 1.5rem;
+        }
+
+        .sidebar-toggle-icon .icon-close {
+            display: none;
+        }
+
+        body.sidebar-collapsed .sidebar-toggle-icon .icon-open {
+            display: none;
+        }
+
+        body.sidebar-collapsed .sidebar-toggle-icon .icon-close {
+            display: inline;
+        }
+
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
         .brand {
             display: flex;
             align-items: center;
@@ -425,8 +458,12 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
     </style>
 </head>
 <body>
-    <button type="button" class="sidebar-toggle" aria-expanded="true" aria-controls="nexa-sidebar">
-        Menüyü Gizle
+    <button type="button" class="sidebar-toggle" aria-expanded="true" aria-controls="nexa-sidebar" aria-label="Menüyü Gizle">
+        <span class="sidebar-toggle-icon" aria-hidden="true">
+            <span class="icon-open" aria-hidden="true">☰</span>
+            <span class="icon-close" aria-hidden="true">✕</span>
+        </span>
+        <span class="visually-hidden sidebar-toggle-text">Menüyü Gizle</span>
     </button>
 
     <aside id="nexa-sidebar" class="sidebar" aria-label="Ana menü">
@@ -547,11 +584,24 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
         const dropdownMenu = document.querySelector('.dropdown-menu');
         const navSubmenus = document.querySelectorAll('details.nav-submenu');
 
+        const toggleText = sidebarToggle ? sidebarToggle.querySelector('.sidebar-toggle-text') : null;
+
+        function updateToggleLabel(isCollapsed) {
+            const label = isCollapsed ? 'Menüyü Göster' : 'Menüyü Gizle';
+            if (sidebarToggle) {
+                sidebarToggle.setAttribute('aria-label', label);
+            }
+
+            if (toggleText) {
+                toggleText.textContent = label;
+            }
+        }
+
         if (sidebar && sidebarToggle) {
             sidebarToggle.addEventListener('click', () => {
                 const isCollapsed = body.classList.toggle('sidebar-collapsed');
                 sidebarToggle.setAttribute('aria-expanded', String(!isCollapsed));
-                sidebarToggle.textContent = isCollapsed ? 'Menüyü Göster' : 'Menüyü Gizle';
+                updateToggleLabel(isCollapsed);
 
                 if (!isCollapsed && typeof sidebar.focus === 'function') {
                     sidebar.setAttribute('tabindex', '-1');
@@ -559,6 +609,8 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
                     sidebar.removeAttribute('tabindex');
                 }
             });
+
+            updateToggleLabel(body.classList.contains('sidebar-collapsed'));
         }
 
         function closeDropdown(event) {

--- a/sidebar.php
+++ b/sidebar.php
@@ -179,16 +179,16 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
             min-width: 1.5rem;
         }
 
-        .sidebar-toggle-icon .icon-close {
+        .sidebar-toggle-icon .icon-open {
             display: none;
         }
 
         body.sidebar-collapsed .sidebar-toggle-icon .icon-open {
-            display: none;
+            display: inline;
         }
 
         body.sidebar-collapsed .sidebar-toggle-icon .icon-close {
-            display: inline;
+            display: none;
         }
 
         .visually-hidden {

--- a/sidebar.php
+++ b/sidebar.php
@@ -119,6 +119,17 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
             color: var(--text-primary);
             display: flex;
             min-height: 100vh;
+            position: relative;
+        }
+
+        body.sidebar-collapsed .sidebar {
+            transform: translateX(-100%);
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        body.sidebar-collapsed .sidebar-toggle {
+            left: var(--spacing-lg);
         }
 
         .sidebar {
@@ -130,6 +141,33 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
             padding: var(--spacing-xl);
             gap: var(--spacing-xl);
             box-shadow: var(--shadow-md);
+            transition: transform var(--transition-fast), opacity var(--transition-fast);
+        }
+
+        .sidebar-toggle {
+            position: fixed;
+            top: var(--spacing-lg);
+            left: calc(min(320px, 80vw) + var(--spacing-lg));
+            z-index: 100;
+            display: inline-flex;
+            align-items: center;
+            gap: var(--spacing-xs);
+            padding: var(--spacing-sm) var(--spacing-md);
+            border-radius: var(--radius-lg);
+            border: 1px solid var(--border-secondary);
+            background-color: var(--surface-primary);
+            color: inherit;
+            cursor: pointer;
+            font: inherit;
+            box-shadow: var(--shadow-sm);
+            transition: background-color var(--transition-fast), transform var(--transition-fast);
+        }
+
+        .sidebar-toggle:hover,
+        .sidebar-toggle:focus-visible {
+            background-color: var(--surface-secondary);
+            outline: none;
+            transform: translateY(-1px);
         }
 
         .brand {
@@ -387,7 +425,11 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
     </style>
 </head>
 <body>
-    <aside class="sidebar" aria-label="Ana menü">
+    <button type="button" class="sidebar-toggle" aria-expanded="true" aria-controls="nexa-sidebar">
+        Menüyü Gizle
+    </button>
+
+    <aside id="nexa-sidebar" class="sidebar" aria-label="Ana menü">
         <header class="brand">
             <div class="brand-logo" aria-hidden="true">N</div>
             <div class="brand-name">
@@ -497,10 +539,27 @@ $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTE
     </aside>
 
     <script>
+        const body = document.body;
+        const sidebar = document.querySelector('#nexa-sidebar');
+        const sidebarToggle = document.querySelector('.sidebar-toggle');
         const profileActions = document.querySelector('.profile-actions');
         const toggleButton = document.querySelector('.dropdown-toggle');
         const dropdownMenu = document.querySelector('.dropdown-menu');
         const navSubmenus = document.querySelectorAll('details.nav-submenu');
+
+        if (sidebar && sidebarToggle) {
+            sidebarToggle.addEventListener('click', () => {
+                const isCollapsed = body.classList.toggle('sidebar-collapsed');
+                sidebarToggle.setAttribute('aria-expanded', String(!isCollapsed));
+                sidebarToggle.textContent = isCollapsed ? 'Menüyü Göster' : 'Menüyü Gizle';
+
+                if (!isCollapsed && typeof sidebar.focus === 'function') {
+                    sidebar.setAttribute('tabindex', '-1');
+                    sidebar.focus({ preventScroll: true });
+                    sidebar.removeAttribute('tabindex');
+                }
+            });
+        }
 
         function closeDropdown(event) {
             if (!profileActions.contains(event.target)) {


### PR DESCRIPTION
## Summary
- add a fixed toggle button that can hide or reveal the sidebar
- animate the sidebar collapse/expansion and reposition the toggle when hidden
- enhance the client script to manage toggle state and restore focus accessibly

## Testing
- php -l sidebar.php

------
https://chatgpt.com/codex/tasks/task_e_68dbb71223508328a31cbda2c4f732b6