### PR TITLE
Remove dashboard header paragraph width limit

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -113,7 +113,6 @@ if (!empty($_SESSION['flash']) && is_array($_SESSION['flash'])) {
 
         .dashboard-header p {
             color: var(--text-secondary);
-            max-width: 520px;
         }
 
         .flash-messages {


### PR DESCRIPTION
## Summary
- remove the max-width restriction from the dashboard header description so it can align with the sidebar layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbb3f71ec8328b0ded3c627ce17f4