### PR TITLE
Add authentication pages and company management API

### DIFF
--- a/api/company/add.php
+++ b/api/company/add.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    json_response([
+        'success' => false,
+        'message' => 'Yalnızca POST isteklerine izin verilir.',
+    ], 405);
+}
+
+$user = require_api_user();
+
+$token = $_POST['csrf_token'] ?? ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+if (!validate_csrf_token(is_string($token) ? $token : null)) {
+    json_response([
+        'success' => false,
+        'message' => 'CSRF doğrulaması başarısız oldu.',
+    ], 400);
+}
+
+$name = trim($_POST['name'] ?? '');
+$adres = trim($_POST['adres'] ?? '');
+$phone = trim($_POST['phone'] ?? '');
+$fax = trim($_POST['fax'] ?? '');
+$website = trim($_POST['website'] ?? '');
+
+if ($name === '') {
+    json_response([
+        'success' => false,
+        'message' => 'Şirket adı zorunludur.',
+    ], 422);
+}
+
+$pdo = get_db_connection();
+$existingStmt = $pdo->prepare('SELECT COUNT(*) FROM company WHERE user_id = :user_id');
+$existingStmt->execute([':user_id' => $user['id']]);
+
+if ((int) $existingStmt->fetchColumn() > 0) {
+    json_response([
+        'success' => false,
+        'message' => 'Zaten bir şirket kaydınız bulunuyor. Güncelleme yapabilirsiniz.',
+    ], 409);
+}
+
+$insertStmt = $pdo->prepare('INSERT INTO company (user_id, name, adres, phone, fax, website) VALUES (:user_id, :name, :adres, :phone, :fax, :website)');
+$insertStmt->execute([
+    ':user_id' => $user['id'],
+    ':name' => $name,
+    ':adres' => $adres !== '' ? $adres : null,
+    ':phone' => $phone !== '' ? $phone : null,
+    ':fax' => $fax !== '' ? $fax : null,
+    ':website' => $website !== '' ? $website : null,
+]);
+
+json_response([
+    'success' => true,
+    'message' => 'Şirket kaydı başarıyla oluşturuldu.',
+    'company_id' => (int) $pdo->lastInsertId(),
+]);

--- a/api/company/delete.php
+++ b/api/company/delete.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    json_response([
+        'success' => false,
+        'message' => 'Yalnızca POST isteklerine izin verilir.',
+    ], 405);
+}
+
+$user = require_api_user();
+
+$token = $_POST['csrf_token'] ?? ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+if (!validate_csrf_token(is_string($token) ? $token : null)) {
+    json_response([
+        'success' => false,
+        'message' => 'CSRF doğrulaması başarısız oldu.',
+    ], 400);
+}
+
+$id = isset($_POST['id']) ? (int) $_POST['id'] : 0;
+if ($id <= 0) {
+    json_response([
+        'success' => false,
+        'message' => 'Geçersiz şirket kimliği.',
+    ], 422);
+}
+
+$pdo = get_db_connection();
+$companyStmt = $pdo->prepare('SELECT id FROM company WHERE id = :id AND user_id = :user_id LIMIT 1');
+$companyStmt->execute([
+    ':id' => $id,
+    ':user_id' => $user['id'],
+]);
+
+if (!$companyStmt->fetch()) {
+    json_response([
+        'success' => false,
+        'message' => 'Şirket kaydı bulunamadı.',
+    ], 404);
+}
+
+$deleteStmt = $pdo->prepare('DELETE FROM company WHERE id = :id');
+$deleteStmt->execute([':id' => $id]);
+
+json_response([
+    'success' => true,
+    'message' => 'Şirket kaydı silindi.',
+]);

--- a/api/company/edit.php
+++ b/api/company/edit.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    json_response([
+        'success' => false,
+        'message' => 'Yalnızca POST isteklerine izin verilir.',
+    ], 405);
+}
+
+$user = require_api_user();
+
+$token = $_POST['csrf_token'] ?? ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+if (!validate_csrf_token(is_string($token) ? $token : null)) {
+    json_response([
+        'success' => false,
+        'message' => 'CSRF doğrulaması başarısız oldu.',
+    ], 400);
+}
+
+$id = isset($_POST['id']) ? (int) $_POST['id'] : 0;
+$name = trim($_POST['name'] ?? '');
+$adres = trim($_POST['adres'] ?? '');
+$phone = trim($_POST['phone'] ?? '');
+$fax = trim($_POST['fax'] ?? '');
+$website = trim($_POST['website'] ?? '');
+
+if ($id <= 0) {
+    json_response([
+        'success' => false,
+        'message' => 'Geçersiz şirket kimliği.',
+    ], 422);
+}
+
+if ($name === '') {
+    json_response([
+        'success' => false,
+        'message' => 'Şirket adı zorunludur.',
+    ], 422);
+}
+
+$pdo = get_db_connection();
+$companyStmt = $pdo->prepare('SELECT id FROM company WHERE id = :id AND user_id = :user_id LIMIT 1');
+$companyStmt->execute([
+    ':id' => $id,
+    ':user_id' => $user['id'],
+]);
+
+if (!$companyStmt->fetch()) {
+    json_response([
+        'success' => false,
+        'message' => 'Şirket kaydı bulunamadı.',
+    ], 404);
+}
+
+$updateStmt = $pdo->prepare('UPDATE company SET name = :name, adres = :adres, phone = :phone, fax = :fax, website = :website WHERE id = :id');
+$updateStmt->execute([
+    ':name' => $name,
+    ':adres' => $adres !== '' ? $adres : null,
+    ':phone' => $phone !== '' ? $phone : null,
+    ':fax' => $fax !== '' ? $fax : null,
+    ':website' => $website !== '' ? $website : null,
+    ':id' => $id,
+]);
+
+json_response([
+    'success' => true,
+    'message' => 'Şirket bilgileri güncellendi.',
+]);

--- a/company.php
+++ b/company.php
@@ -1,0 +1,216 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+$user = require_login();
+$pdo = get_db_connection();
+
+$companyStmt = $pdo->prepare('SELECT id, name, adres, phone, fax, website, created_at, updated_at FROM company WHERE user_id = :user_id LIMIT 1');
+$companyStmt->execute([':user_id' => $user['id']]);
+$company = $companyStmt->fetch() ?: null;
+
+$pageTitle = 'Şirket Bilgileri - Nexa';
+include __DIR__ . '/header.php';
+?>
+<div class="container-fluid">
+    <div class="row">
+        <?php include __DIR__ . '/sidebar.php'; ?>
+        <main class="col-lg-10 ms-auto px-4 py-4">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between mb-4">
+                <div>
+                    <h1 class="h3 fw-semibold mb-1">Şirket Bilgileri</h1>
+                    <p class="text-muted mb-0">Şirket kartınızı güncel tutun. Tüm değişiklikler anında kaydedilir.</p>
+                </div>
+                <button id="toggleCompanyForm" class="btn btn-primary mt-3 mt-lg-0">
+                    <i class="bi bi-pencil-square me-2"></i><?= $company ? 'Bilgileri düzenle' : 'Yeni şirket ekle' ?>
+                </button>
+            </div>
+
+            <div class="row g-4">
+                <div class="col-12 col-xl-6">
+                    <div class="card shadow-sm border-0 h-100">
+                        <div class="card-body">
+                            <h2 class="h5 fw-semibold mb-3">Mevcut Durum</h2>
+                            <?php if ($company): ?>
+                                <dl class="row mb-0 small">
+                                    <dt class="col-sm-4 text-muted">Şirket adı</dt>
+                                    <dd class="col-sm-8 fw-medium"><?= e($company['name']) ?></dd>
+
+                                    <dt class="col-sm-4 text-muted">Adres</dt>
+                                    <dd class="col-sm-8"><?= $company['adres'] ? nl2br(e($company['adres'])) : '<span class="text-muted">Belirtilmemiş</span>' ?></dd>
+
+                                    <dt class="col-sm-4 text-muted">Telefon</dt>
+                                    <dd class="col-sm-8"><?= $company['phone'] ? e($company['phone']) : '<span class="text-muted">Belirtilmemiş</span>' ?></dd>
+
+                                    <dt class="col-sm-4 text-muted">Faks</dt>
+                                    <dd class="col-sm-8"><?= $company['fax'] ? e($company['fax']) : '<span class="text-muted">Belirtilmemiş</span>' ?></dd>
+
+                                    <dt class="col-sm-4 text-muted">Web sitesi</dt>
+                                    <dd class="col-sm-8">
+                                        <?php if ($company['website']): ?>
+                                            <a href="<?= e($company['website']) ?>" target="_blank" rel="noopener"><?= e($company['website']) ?></a>
+                                        <?php else: ?>
+                                            <span class="text-muted">Belirtilmemiş</span>
+                                        <?php endif; ?>
+                                    </dd>
+
+                                    <dt class="col-sm-4 text-muted">Son güncelleme</dt>
+                                    <dd class="col-sm-8"><?= e((new DateTimeImmutable($company['updated_at']))->format('d.m.Y H:i')) ?></dd>
+                                </dl>
+                                <button id="deleteCompany" class="btn btn-outline-danger btn-sm mt-4" data-company-id="<?= (int) $company['id'] ?>">
+                                    <i class="bi bi-trash me-1"></i>Şirketi sil
+                                </button>
+                            <?php else: ?>
+                                <p class="text-muted mb-0">Henüz herhangi bir şirket bilgisi eklenmemiş. Başlamak için sağ üstteki butondan formu açın.</p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-xl-6">
+                    <div class="card shadow-sm border-0 <?= $company ? 'd-none' : '' ?>" id="companyFormCard">
+                        <div class="card-body">
+                            <h2 class="h5 fw-semibold mb-3">Şirket Formu</h2>
+                            <form id="companyForm" class="needs-validation" novalidate>
+                                <input type="hidden" name="id" value="<?= $company ? (int) $company['id'] : '' ?>">
+                                <input type="hidden" name="csrf_token" value="<?= e(ensure_csrf_token()) ?>">
+                                <div class="mb-3">
+                                    <label class="form-label" for="companyName">Şirket adı <span class="text-danger">*</span></label>
+                                    <input class="form-control" type="text" id="companyName" name="name" value="<?= $company ? e($company['name']) : '' ?>" required>
+                                    <div class="invalid-feedback">Bu alan zorunludur.</div>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label" for="companyAddress">Adres</label>
+                                    <textarea class="form-control" id="companyAddress" name="adres" rows="3"><?= $company ? e($company['adres'] ?? '') : '' ?></textarea>
+                                </div>
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        <label class="form-label" for="companyPhone">Telefon</label>
+                                        <input class="form-control" type="text" id="companyPhone" name="phone" value="<?= $company ? e($company['phone'] ?? '') : '' ?>">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label" for="companyFax">Faks</label>
+                                        <input class="form-control" type="text" id="companyFax" name="fax" value="<?= $company ? e($company['fax'] ?? '') : '' ?>">
+                                    </div>
+                                </div>
+                                <div class="mt-3">
+                                    <label class="form-label" for="companyWebsite">Web sitesi</label>
+                                    <input class="form-control" type="url" id="companyWebsite" name="website" value="<?= $company ? e($company['website'] ?? '') : '' ?>" placeholder="https://">
+                                </div>
+                                <div class="d-grid d-md-flex gap-2 mt-4">
+                                    <button class="btn btn-primary" type="submit"><i class="bi bi-save me-2"></i>Kaydet</button>
+                                    <button class="btn btn-outline-secondary" type="button" id="cancelCompanyForm">İptal</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<script>
+(() => {
+    const formCard = document.getElementById('companyFormCard');
+    const toggleBtn = document.getElementById('toggleCompanyForm');
+    const cancelBtn = document.getElementById('cancelCompanyForm');
+    const companyForm = document.getElementById('companyForm');
+    const deleteBtn = document.getElementById('deleteCompany');
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+    function showForm() {
+        formCard.classList.remove('d-none');
+        formCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    function hideForm() {
+        if (!companyForm.querySelector('input[name="id"]').value) {
+            companyForm.reset();
+        }
+        formCard.classList.add('d-none');
+    }
+
+    if (toggleBtn) {
+        toggleBtn.addEventListener('click', () => {
+            formCard.classList.toggle('d-none');
+        });
+    }
+
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', hideForm);
+    }
+
+    if (companyForm) {
+        companyForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            if (!companyForm.checkValidity()) {
+                companyForm.classList.add('was-validated');
+                return;
+            }
+
+            const formData = new FormData(companyForm);
+            const hasId = Boolean(formData.get('id'));
+            const endpoint = hasId ? '/api/company/edit.php' : '/api/company/add.php';
+
+            try {
+                const response = await fetch(endpoint, {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-Token': csrfToken,
+                    },
+                    body: formData,
+                });
+
+                const payload = await response.json();
+
+                if (!response.ok || !payload.success) {
+                    throw new Error(payload.message || 'İşlem sırasında bir hata oluştu.');
+                }
+
+                window.location.reload();
+            } catch (error) {
+                alert(error.message);
+            }
+        });
+    }
+
+    if (deleteBtn) {
+        deleteBtn.addEventListener('click', async () => {
+            const companyId = deleteBtn.getAttribute('data-company-id');
+            if (!companyId) {
+                return;
+            }
+
+            if (!confirm('Şirket kaydını silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.')) {
+                return;
+            }
+
+            const formData = new FormData();
+            formData.set('id', companyId);
+            formData.set('csrf_token', csrfToken);
+
+            try {
+                const response = await fetch('/api/company/delete.php', {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-Token': csrfToken,
+                    },
+                    body: formData,
+                });
+
+                const payload = await response.json();
+
+                if (!response.ok || !payload.success) {
+                    throw new Error(payload.message || 'Şirket silinirken bir hata oluştu.');
+                }
+
+                window.location.reload();
+            } catch (error) {
+                alert(error.message);
+            }
+        });
+    }
+})();
+</script>
+</body>
+</html>

--- a/config.php
+++ b/config.php
@@ -1,0 +1,11 @@
+<?php
+return [
+    'db' => [
+        'host' => '127.0.0.1',
+        'port' => 3306,
+        'name' => 'nexa',
+        'user' => 'nexa_user',
+        'password' => 'nexa_pass',
+        'charset' => 'utf8mb4',
+    ],
+];

--- a/config.php
+++ b/config.php
@@ -4,8 +4,8 @@ return [
         'host' => '127.0.0.1',
         'port' => 3306,
         'name' => 'nexa',
-        'user' => 'nexa_user',
-        'password' => 'nexa_pass',
+        'user' => 'root',
+        'password' => '',
         'charset' => 'utf8mb4',
     ],
 ];

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+$user = require_login();
+
+$pdo = get_db_connection();
+$companyCountStmt = $pdo->prepare('SELECT COUNT(*) FROM company WHERE user_id = :user_id');
+$companyCountStmt->execute([':user_id' => $user['id']]);
+$companyCount = (int) $companyCountStmt->fetchColumn();
+
+$pageTitle = 'Panel - Nexa';
+include __DIR__ . '/header.php';
+?>
+<div class="container-fluid">
+    <div class="row">
+        <?php include __DIR__ . '/sidebar.php'; ?>
+        <main class="col-lg-10 ms-auto px-4 py-4">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between mb-4">
+                <div>
+                    <h1 class="h3 fw-semibold mb-1">Merhaba, <?= e($user['firstname']) ?> 👋</h1>
+                    <p class="text-muted mb-0">Kontrol panelinize hoş geldiniz. Şirket bilgilerinizi buradan yönetebilirsiniz.</p>
+                </div>
+                <a href="/company.php" class="btn btn-primary mt-3 mt-lg-0"><i class="bi bi-building me-2"></i>Şirket Detayları</a>
+            </div>
+            <div class="row g-4">
+                <div class="col-md-6 col-xl-4">
+                    <div class="card shadow-sm border-0 h-100">
+                        <div class="card-body">
+                            <div class="d-flex align-items-center justify-content-between">
+                                <div>
+                                    <h2 class="display-6 fw-semibold mb-0"><?= $companyCount ?></h2>
+                                    <p class="text-muted mb-0">Kayıtlı şirket</p>
+                                </div>
+                                <div class="rounded-circle bg-primary-subtle text-primary d-flex align-items-center justify-content-center" style="width: 56px; height: 56px;">
+                                    <i class="bi bi-buildings fs-4"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-6 col-xl-4">
+                    <div class="card shadow-sm border-0 h-100">
+                        <div class="card-body">
+                            <h6 class="text-muted text-uppercase">Güvenlik</h6>
+                            <p class="mb-2">Şifreniz güçlü şifreleme algoritmasıyla korunur.</p>
+                            <span class="badge bg-success-subtle text-success"><i class="bi bi-shield-lock me-1"></i>Etkin</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-6 col-xl-4">
+                    <div class="card shadow-sm border-0 h-100">
+                        <div class="card-body">
+                            <h6 class="text-muted text-uppercase">Başlamak için</h6>
+                            <ul class="list-unstyled mb-0 small">
+                                <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Şirket bilgilerinizi ekleyin.</li>
+                                <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Gerekirse güncelleme yapın.</li>
+                                <li class="mb-0"><i class="bi bi-check-circle-fill text-success me-2"></i>Bilgileri ekibinizle paylaşın.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/header.php
+++ b/header.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+$pageTitle = $pageTitle ?? 'Nexa';
+$csrfToken = ensure_csrf_token();
+$user = current_user();
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="<?= e($csrfToken) ?>">
+    <title><?= e($pageTitle) ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f5f6fa;
+        }
+        .sidebar {
+            min-height: 100vh;
+            background: #111827;
+        }
+        .sidebar a {
+            color: rgba(255, 255, 255, 0.75);
+        }
+        .sidebar a.active,
+        .sidebar a:hover {
+            color: #fff;
+            background-color: rgba(255, 255, 255, 0.1);
+        }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm">
+    <div class="container-fluid">
+        <a class="navbar-brand fw-semibold" href="/">Nexa</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto align-items-lg-center gap-lg-2">
+                <?php if ($user === null): ?>
+                    <li class="nav-item"><a class="nav-link" href="/login.php">Giriş Yap</a></li>
+                    <li class="nav-item"><a class="btn btn-primary" href="/register.php">Kayıt Ol</a></li>
+                <?php else: ?>
+                    <li class="nav-item"><a class="nav-link" href="/dashboard.php">Panel</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/company.php">Şirket Bilgileri</a></li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i><?= e($user['firstname'] . ' ' . $user['lastname']) ?>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <li><span class="dropdown-item-text text-muted small"><?= e($user['email']) ?></span></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" href="/logout.php">Çıkış Yap</a></li>
+                        </ul>
+                    </li>
+                <?php endif; ?>
+            </ul>
+        </div>
+    </div>
+</nav>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -65,11 +65,24 @@ function get_db_connection(): PDO
 
     $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=%s', $dbHost, $dbPort, $dbName, $charset);
 
-    $pdo = new PDO($dsn, $dbUser, $dbPass, [
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        PDO::ATTR_EMULATE_PREPARES => false,
-    ]);
+    try {
+        $pdo = new PDO($dsn, $dbUser, $dbPass, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ]);
+    } catch (PDOException $exception) {
+        $message = 'Database connection failed. Please verify your database credentials in config.php or environment variables.';
+
+        if (PHP_SAPI === 'cli') {
+            throw new RuntimeException($message, 0, $exception);
+        }
+
+        error_log($exception->getMessage());
+        http_response_code(500);
+        echo $message;
+        exit;
+    }
 
     return $pdo;
 }

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+/**
+ * Returns the shared PDO connection.
+ */
+function get_db_connection(): PDO
+{
+    static $pdo = null;
+
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $dbHost = getenv('DB_HOST') ?: '127.0.0.1';
+    $dbPort = getenv('DB_PORT') ?: '3306';
+    $dbName = getenv('DB_NAME') ?: 'nexa';
+    $dbUser = getenv('DB_USER') ?: 'nexa_user';
+    $dbPass = getenv('DB_PASSWORD') ?: 'nexa_pass';
+
+    $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $dbHost, $dbPort, $dbName);
+
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ]);
+
+    return $pdo;
+}
+
+/**
+ * Returns the authenticated user array or null.
+ */
+function current_user(): ?array
+{
+    return $_SESSION['user'] ?? null;
+}
+
+/**
+ * Redirects to the login page when the visitor is not authenticated.
+ * Returns the user array otherwise.
+ */
+function require_login(): array
+{
+    $user = current_user();
+    if ($user === null) {
+        header('Location: /login.php');
+        exit;
+    }
+
+    return $user;
+}
+
+/**
+ * Ensures the visitor is authenticated for API requests.
+ */
+function require_api_user(): array
+{
+    $user = current_user();
+    if ($user === null) {
+        json_response([
+            'success' => false,
+            'message' => 'Authentication required.',
+        ], 401);
+    }
+
+    return $user;
+}
+
+/**
+ * Redirects authenticated users away from public pages.
+ */
+function redirect_if_logged_in(): void
+{
+    if (current_user() !== null) {
+        header('Location: /dashboard.php');
+        exit;
+    }
+}
+
+/**
+ * Returns an escaped string suitable for HTML output.
+ */
+function e(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+/**
+ * Ensures a CSRF token exists for the current session and returns it.
+ */
+function ensure_csrf_token(): string
+{
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+
+    return $_SESSION['csrf_token'];
+}
+
+/**
+ * Validates an incoming CSRF token against the session token.
+ */
+function validate_csrf_token(?string $token): bool
+{
+    if (empty($_SESSION['csrf_token']) || $token === null) {
+        return false;
+    }
+
+    return hash_equals($_SESSION['csrf_token'], $token);
+}
+
+/**
+ * Sends a JSON response and terminates execution.
+ */
+function json_response(array $data, int $statusCode = 200): void
+{
+    http_response_code($statusCode);
+    header('Content-Type: application/json');
+    echo json_encode($data);
+    exit;
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+$pageTitle = 'Nexa - Modern İş Yönetimi';
+include __DIR__ . '/header.php';
+?>
+<main class="container py-5">
+    <div class="row align-items-center justify-content-between g-5">
+        <div class="col-lg-6">
+            <h1 class="display-4 fw-bold mb-3">Nexa ile işinizi kolaylaştırın</h1>
+            <p class="lead text-muted mb-4">Şirket bilgilerinizi tek noktadan yönetin, ekip arkadaşlarınızla paylaşın ve güncel tutun. Nexa ile süreçleriniz hem daha hızlı hem daha güvenli.</p>
+            <div class="d-flex gap-3">
+                <a class="btn btn-primary btn-lg" href="/register.php">Hemen Başlayın</a>
+                <a class="btn btn-outline-secondary btn-lg" href="/login.php">Zaten hesabım var</a>
+            </div>
+        </div>
+        <div class="col-lg-5">
+            <div class="card border-0 shadow-sm">
+                <div class="card-body p-4">
+                    <h2 class="h4 fw-semibold mb-3">Nexa'yı neden tercih etmelisiniz?</h2>
+                    <ul class="list-unstyled small text-muted mb-0">
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Basit ve sezgisel arayüz</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Güvenli kullanıcı yönetimi</li>
+                        <li class="mb-2"><i class="bi bi-check-circle-fill text-success me-2"></i>Gerçek zamanlı şirket güncellemeleri</li>
+                        <li class="mb-0"><i class="bi bi-check-circle-fill text-success me-2"></i>Esnek API mimarisi</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+redirect_if_logged_in();
+
+$errors = [];
+$username = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $token = $_POST['csrf_token'] ?? '';
+
+    if (!validate_csrf_token($token)) {
+        $errors[] = 'Oturum doğrulaması başarısız oldu. Lütfen sayfayı yenileyin.';
+    }
+
+    if ($username === '' || $password === '') {
+        $errors[] = 'Kullanıcı adı/e-posta ve şifre zorunludur.';
+    }
+
+    if (!$errors) {
+        $pdo = get_db_connection();
+        $stmt = $pdo->prepare('SELECT id, firstname, lastname, email, username, password FROM users WHERE username = :username OR email = :username LIMIT 1');
+        $stmt->execute([':username' => $username]);
+        $user = $stmt->fetch();
+
+        if (!$user || !password_verify($password, (string) $user['password'])) {
+            $errors[] = 'Geçersiz kullanıcı bilgileri.';
+        } else {
+            unset($user['password']);
+            $_SESSION['user'] = $user;
+            header('Location: /dashboard.php');
+            exit;
+        }
+    }
+}
+
+$pageTitle = 'Giriş Yap - Nexa';
+include __DIR__ . '/header.php';
+?>
+<main class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-5">
+            <div class="card shadow-sm border-0">
+                <div class="card-body p-4">
+                    <h1 class="h3 fw-semibold mb-3 text-center">Giriş Yap</h1>
+                    <?php if ($errors): ?>
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                <?php foreach ($errors as $error): ?>
+                                    <li><?= e($error) ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                    <?php endif; ?>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="csrf_token" value="<?= e(ensure_csrf_token()) ?>">
+                        <div class="mb-3">
+                            <label class="form-label" for="username">Kullanıcı adı veya e-posta</label>
+                            <input class="form-control" type="text" id="username" name="username" value="<?= e($username) ?>" required autofocus>
+                        </div>
+                        <div class="mb-4">
+                            <label class="form-label" for="password">Şifre</label>
+                            <input class="form-control" type="password" id="password" name="password" required>
+                        </div>
+                        <button class="btn btn-primary w-100" type="submit">Giriş Yap</button>
+                    </form>
+                    <p class="text-center small text-muted mt-3 mb-0">Hesabınız yok mu? <a href="/register.php">Kayıt olun</a>.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+session_regenerate_id(true);
+$_SESSION = [];
+session_destroy();
+
+header('Location: /');
+exit;

--- a/register.php
+++ b/register.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+redirect_if_logged_in();
+
+$errors = [];
+$form = [
+    'firstname' => '',
+    'lastname' => '',
+    'email' => '',
+    'username' => '',
+];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $form['firstname'] = trim($_POST['firstname'] ?? '');
+    $form['lastname'] = trim($_POST['lastname'] ?? '');
+    $form['email'] = trim($_POST['email'] ?? '');
+    $form['username'] = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $passwordConfirm = $_POST['password_confirm'] ?? '';
+    $token = $_POST['csrf_token'] ?? '';
+
+    if (!validate_csrf_token($token)) {
+        $errors[] = 'Oturum doğrulaması başarısız oldu. Lütfen sayfayı yenileyin.';
+    }
+
+    if ($form['firstname'] === '' || $form['lastname'] === '') {
+        $errors[] = 'Ad ve soyad zorunludur.';
+    }
+
+    if (!filter_var($form['email'], FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Geçerli bir e-posta adresi girin.';
+    }
+
+    if ($form['username'] === '') {
+        $errors[] = 'Kullanıcı adı zorunludur.';
+    }
+
+    if ($password === '' || $passwordConfirm === '') {
+        $errors[] = 'Şifre ve şifre doğrulama zorunludur.';
+    } elseif ($password !== $passwordConfirm) {
+        $errors[] = 'Şifreler birbiriyle uyuşmuyor.';
+    } elseif (strlen($password) < 8) {
+        $errors[] = 'Şifreniz en az 8 karakter olmalıdır.';
+    }
+
+    if (!$errors) {
+        $pdo = get_db_connection();
+        $stmt = $pdo->prepare('SELECT COUNT(*) FROM users WHERE email = :email OR username = :username');
+        $stmt->execute([
+            ':email' => $form['email'],
+            ':username' => $form['username'],
+        ]);
+
+        if ($stmt->fetchColumn() > 0) {
+            $errors[] = 'Bu e-posta veya kullanıcı adı zaten kullanımda.';
+        } else {
+            $stmt = $pdo->prepare('INSERT INTO users (firstname, lastname, email, username, password) VALUES (:firstname, :lastname, :email, :username, :password)');
+            $stmt->execute([
+                ':firstname' => $form['firstname'],
+                ':lastname' => $form['lastname'],
+                ':email' => $form['email'],
+                ':username' => $form['username'],
+                ':password' => password_hash($password, PASSWORD_DEFAULT),
+            ]);
+
+            $_SESSION['user'] = [
+                'id' => (int) $pdo->lastInsertId(),
+                'firstname' => $form['firstname'],
+                'lastname' => $form['lastname'],
+                'email' => $form['email'],
+                'username' => $form['username'],
+            ];
+
+            header('Location: /dashboard.php');
+            exit;
+        }
+    }
+}
+
+$pageTitle = 'Kayıt Ol - Nexa';
+include __DIR__ . '/header.php';
+?>
+<main class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-6">
+            <div class="card shadow-sm border-0">
+                <div class="card-body p-4">
+                    <h1 class="h3 fw-semibold mb-3 text-center">Hesap Oluştur</h1>
+                    <?php if ($errors): ?>
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                <?php foreach ($errors as $error): ?>
+                                    <li><?= e($error) ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                    <?php endif; ?>
+                    <form method="post" novalidate>
+                        <input type="hidden" name="csrf_token" value="<?= e(ensure_csrf_token()) ?>">
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label" for="firstname">Ad</label>
+                                <input class="form-control" type="text" id="firstname" name="firstname" value="<?= e($form['firstname']) ?>" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="lastname">Soyad</label>
+                                <input class="form-control" type="text" id="lastname" name="lastname" value="<?= e($form['lastname']) ?>" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="email">E-posta</label>
+                                <input class="form-control" type="email" id="email" name="email" value="<?= e($form['email']) ?>" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="username">Kullanıcı adı</label>
+                                <input class="form-control" type="text" id="username" name="username" value="<?= e($form['username']) ?>" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="password">Şifre</label>
+                                <input class="form-control" type="password" id="password" name="password" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="password_confirm">Şifre (tekrar)</label>
+                                <input class="form-control" type="password" id="password_confirm" name="password_confirm" required>
+                            </div>
+                        </div>
+                        <button class="btn btn-primary w-100 mt-4" type="submit">Kayıt Ol</button>
+                    </form>
+                    <p class="text-center small text-muted mt-3 mb-0">Zaten hesabınız var mı? <a href="/login.php">Giriş yapın</a>.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+
+$user = current_user();
+
+if ($user === null) {
+    return;
+}
+?>
+<aside class="sidebar col-12 col-lg-2 d-flex flex-column p-3 text-white">
+    <h5 class="text-white mb-4">Kontrol Paneli</h5>
+    <ul class="nav nav-pills flex-column gap-1">
+        <li class="nav-item"><a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'dashboard.php' ? 'active' : ''; ?>" href="/dashboard.php"><i class="bi bi-speedometer me-2"></i>Özet</a></li>
+        <li class="nav-item"><a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'company.php' ? 'active' : ''; ?>" href="/company.php"><i class="bi bi-building me-2"></i>Şirket</a></li>
+    </ul>
+</aside>


### PR DESCRIPTION
## Summary
- add a shared bootstrap file with database helpers, session utilities, and CSRF protection
- create landing, authentication, and dashboard pages with reusable header/sidebar components
- implement company management UI and API endpoints for adding, editing, and deleting company records

## Testing
- find . -name '*.php' -print0 | xargs -0 -n1 php -l


------
https://chatgpt.com/codex/tasks/task_e_68e4bffbc88c8328836b89be57c77019