### PR TITLE
Fix login query parameter bindings

### DIFF
--- a/login.php
+++ b/login.php
@@ -24,9 +24,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!$errors) {
         $pdo = get_db_connection();
         $stmt = $pdo->prepare(
-            'SELECT id, firstname, lastname, email, username, password FROM users WHERE username = :username OR email = :username LIMIT 1'
+            'SELECT id, firstname, lastname, email, username, password FROM users WHERE username = :username OR email = :email LIMIT 1'
         );
-        $stmt->execute([':username' => $username]);
+        $stmt->execute([
+            ':username' => $username,
+            ':email' => $username,
+        ]);
         $user = $stmt->fetch();
 
         if (!$user || !password_verify($password, (string) $user['password'])) {


### PR DESCRIPTION
## Summary
- adjust the login query to use distinct placeholders for username and email
- bind both placeholders with the submitted username value to avoid invalid parameter errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4cf725e2883288f33b24c94b22e42