### PR TITLE
Revamp sidebar to match dashboard design

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -62,8 +62,8 @@ $navSections = [
     }
 
     .sidebar .profile-avatar {
-        width: 46px;
-        height: 46px;
+        width: 56px;
+        height: 56px;
         border-radius: 50%;
         background: linear-gradient(135deg, rgba(102, 126, 234, 0.85), rgba(118, 75, 162, 0.85));
         padding: 2px;

--- a/sidebar.php
+++ b/sidebar.php
@@ -10,44 +10,70 @@ if ($user === null) {
 }
 
 $currentPage = basename($_SERVER['PHP_SELF']);
-$navItems = [
+$navSections = [
     [
-        'href' => 'dashboard.php',
-        'icon' => 'bi-speedometer',
-        'label' => 'Özet',
-    ],
-    [
-        'href' => 'company.php',
-        'icon' => 'bi-building',
-        'label' => 'Şirket',
-    ],
-    [
-        'href' => 'company_contact.php',
-        'icon' => 'bi-people',
-        'label' => 'İletişim Kişileri',
+        'title' => 'Genel',
+        'items' => [
+            [
+                'href' => 'dashboard.php',
+                'icon' => 'bi-speedometer',
+                'label' => 'Özet',
+            ],
+            [
+                'href' => 'company.php',
+                'icon' => 'bi-building',
+                'label' => 'Şirket',
+            ],
+            [
+                'href' => 'company_contact.php',
+                'icon' => 'bi-people',
+                'label' => 'İletişim Kişileri',
+            ],
+        ],
     ],
 ];
 ?>
-<aside class="sidebar d-none d-lg-flex flex-column flex-shrink-0 align-self-start text-white px-3 py-4 position-sticky top-0 min-vh-100" style="width: 260px;">
-    <div class="d-flex align-items-center justify-content-between mb-4">
-        <span class="fs-5 fw-semibold">Nexa</span>
-        <span class="badge bg-primary-subtle text-primary">Panel</span>
+<aside class="sidebar col-auto d-none d-lg-flex flex-column flex-shrink-0 align-self-start text-white px-3 py-4 position-sticky top-0 min-vh-100" style="width: 260px;">
+    <div class="d-flex align-items-center gap-3 mb-4">
+        <div class="rounded-4 bg-primary-subtle text-primary fw-bold d-flex align-items-center justify-content-center" style="width: 44px; height: 44px;">
+            <span>N</span>
+        </div>
+        <div>
+            <div class="fw-semibold">Nexa</div>
+            <small class="text-white-50">Yönetim Paneli</small>
+        </div>
     </div>
-    <nav class="nav nav-pills flex-column gap-1 mb-auto">
-        <?php foreach ($navItems as $item): ?>
-            <?php $isActive = $currentPage === basename($item['href']); ?>
-            <a class="nav-link d-flex align-items-center px-3 py-2 rounded-3<?php echo $isActive ? ' active' : ''; ?>" href="<?= e($item['href']) ?>">
-                <i class="bi <?= e($item['icon']) ?> me-2"></i>
-                <span><?= e($item['label']) ?></span>
+    <?php foreach ($navSections as $section): ?>
+        <div class="nav-section mb-4 w-100">
+            <div class="text-uppercase text-white-50 fw-semibold small mb-2" style="letter-spacing: .08em;">
+                <?= e($section['title']) ?>
+            </div>
+            <nav class="nav nav-pills flex-column mb-0">
+                <?php foreach ($section['items'] as $item): ?>
+                    <?php $isActive = $currentPage === basename($item['href']); ?>
+                    <a class="nav-link d-flex align-items-center px-3 py-2<?php echo $isActive ? ' active' : ''; ?>" href="<?= e($item['href']) ?>">
+                        <i class="bi <?= e($item['icon']) ?> me-2"></i>
+                        <span><?= e($item['label']) ?></span>
+                    </a>
+                <?php endforeach; ?>
+            </nav>
+        </div>
+    <?php endforeach; ?>
+    <div class="mt-auto w-100">
+        <div class="p-3 rounded-4 bg-white bg-opacity-10 border border-light border-opacity-10">
+            <div class="d-flex align-items-center gap-3">
+                <div class="rounded-circle bg-primary d-flex align-items-center justify-content-center" style="width: 42px; height: 42px;">
+                    <i class="bi bi-person-fill text-white"></i>
+                </div>
+                <div class="flex-grow-1">
+                    <div class="fw-semibold text-white mb-1"><?= e($user['firstname'] . ' ' . $user['lastname']) ?></div>
+                    <div class="text-white-50 text-truncate small"><?= e($user['email']) ?></div>
+                </div>
+            </div>
+            <a class="btn btn-outline-light btn-sm w-100 mt-3" href="logout.php">
+                <i class="bi bi-box-arrow-right me-2"></i>Çıkış Yap
             </a>
-        <?php endforeach; ?>
-    </nav>
-    <div class="mt-auto pt-4 border-top border-light-subtle small">
-        <div class="fw-semibold text-white mb-1"><?= e($user['firstname'] . ' ' . $user['lastname']) ?></div>
-        <div class="text-white-50 text-truncate"><?= e($user['email']) ?></div>
-        <a class="btn btn-outline-light btn-sm w-100 mt-3" href="logout.php">
-            <i class="bi bi-box-arrow-right me-2"></i>Çıkış Yap
-        </a>
+        </div>
     </div>
 </aside>
 <div class="offcanvas offcanvas-start text-bg-dark" tabindex="-1" id="sidebarOffcanvas" aria-labelledby="sidebarOffcanvasLabel">
@@ -56,15 +82,22 @@ $navItems = [
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Kapat"></button>
     </div>
     <div class="offcanvas-body d-flex flex-column">
-        <nav class="nav nav-pills flex-column gap-1 mb-4">
-            <?php foreach ($navItems as $item): ?>
-                <?php $isActive = $currentPage === basename($item['href']); ?>
-                <a class="nav-link d-flex align-items-center px-3 py-2 rounded-3<?php echo $isActive ? ' active' : ''; ?>" href="<?= e($item['href']) ?>">
-                    <i class="bi <?= e($item['icon']) ?> me-2"></i>
-                    <span><?= e($item['label']) ?></span>
-                </a>
-            <?php endforeach; ?>
-        </nav>
+        <?php foreach ($navSections as $section): ?>
+            <div class="nav-section mb-4">
+                <div class="text-uppercase text-white-50 fw-semibold small mb-2" style="letter-spacing: .08em;">
+                    <?= e($section['title']) ?>
+                </div>
+                <nav class="nav nav-pills flex-column">
+                    <?php foreach ($section['items'] as $item): ?>
+                        <?php $isActive = $currentPage === basename($item['href']); ?>
+                        <a class="nav-link d-flex align-items-center px-3 py-2<?php echo $isActive ? ' active' : ''; ?>" href="<?= e($item['href']) ?>">
+                            <i class="bi <?= e($item['icon']) ?> me-2"></i>
+                            <span><?= e($item['label']) ?></span>
+                        </a>
+                    <?php endforeach; ?>
+                </nav>
+            </div>
+        <?php endforeach; ?>
         <div class="mt-auto border-top border-secondary pt-3 small">
             <div class="fw-semibold text-white mb-1"><?= e($user['firstname'] . ' ' . $user['lastname']) ?></div>
             <div class="text-white-50 text-truncate mb-3"><?= e($user['email']) ?></div>

--- a/sidebar.php
+++ b/sidebar.php
@@ -33,6 +33,19 @@ $navSections = [
     ],
 ];
 ?>
+<style>
+    .sidebar .nav-link,
+    .offcanvas .nav-link {
+        transition: color 0.2s ease, background-color 0.2s ease;
+    }
+
+    .sidebar .nav-link.active,
+    .sidebar .nav-link:hover,
+    .offcanvas .nav-link.active,
+    .offcanvas .nav-link:hover {
+        transform: none !important;
+    }
+</style>
 <aside class="sidebar col-auto d-none d-lg-flex flex-column flex-shrink-0 align-self-start text-white px-3 py-4 position-sticky top-0 min-vh-100" style="width: 260px;">
     <div class="d-flex align-items-center gap-3 mb-4">
         <div class="rounded-4 bg-primary-subtle text-primary fw-bold d-flex align-items-center justify-content-center" style="width: 44px; height: 44px;">

--- a/sidebar.php
+++ b/sidebar.php
@@ -85,7 +85,7 @@ $navSections = [
         letter-spacing: 0.02em;
     }
 </style>
-<aside class="sidebar col-auto d-none d-lg-flex flex-column flex-shrink-0 align-self-start text-white px-3 py-4 position-sticky top-0 min-vh-100" style="width: 260px;">
+<aside class="sidebar col-auto d-none d-lg-flex flex-column flex-shrink-0 align-self-start text-white px-3 py-4 position-sticky top-0 min-vh-100" style="width: 280px;">
     <div class="d-flex align-items-center gap-3 mb-4">
         <div class="rounded-4 bg-primary-subtle text-primary fw-bold d-flex align-items-center justify-content-center" style="width: 44px; height: 44px;">
             <span>N</span>

--- a/sidebar.php
+++ b/sidebar.php
@@ -9,6 +9,21 @@ if ($user === null) {
     return;
 }
 
+$firstname = $user['firstname'] ?? '';
+$lastname = $user['lastname'] ?? '';
+
+if (function_exists('mb_substr')) {
+    $firstInitial = mb_substr($firstname, 0, 1, 'UTF-8');
+    $lastInitial = mb_substr($lastname, 0, 1, 'UTF-8');
+    $initials = mb_strtoupper($firstInitial . $lastInitial, 'UTF-8');
+} else {
+    $initials = strtoupper(substr($firstname, 0, 1) . substr($lastname, 0, 1));
+}
+
+if ($initials === '') {
+    $initials = 'N';
+}
+
 $currentPage = basename($_SERVER['PHP_SELF']);
 $navSections = [
     [
@@ -45,6 +60,29 @@ $navSections = [
     .offcanvas .nav-link:hover {
         transform: none !important;
     }
+
+    .sidebar .profile-avatar {
+        width: 46px;
+        height: 46px;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(102, 126, 234, 0.85), rgba(118, 75, 162, 0.85));
+        padding: 2px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .sidebar .profile-avatar-inner {
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        background: rgba(15, 23, 42, 0.9);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+    }
 </style>
 <aside class="sidebar col-auto d-none d-lg-flex flex-column flex-shrink-0 align-self-start text-white px-3 py-4 position-sticky top-0 min-vh-100" style="width: 260px;">
     <div class="d-flex align-items-center gap-3 mb-4">
@@ -75,8 +113,10 @@ $navSections = [
     <div class="mt-auto w-100">
         <div class="p-3 rounded-4 bg-white bg-opacity-10 border border-light border-opacity-10">
             <div class="d-flex align-items-center gap-3">
-                <div class="rounded-circle bg-primary d-flex align-items-center justify-content-center" style="width: 42px; height: 42px;">
-                    <i class="bi bi-person-fill text-white"></i>
+                <div class="profile-avatar">
+                    <div class="profile-avatar-inner text-white">
+                        <span><?= e($initials) ?></span>
+                    </div>
                 </div>
                 <div class="flex-grow-1">
                     <div class="fw-semibold text-white mb-1"><?= e($user['firstname'] . ' ' . $user['lastname']) ?></div>

--- a/sidebar.php
+++ b/sidebar.php
@@ -67,6 +67,7 @@ $navSections = [
         border-radius: 50%;
         background: linear-gradient(135deg, rgba(102, 126, 234, 0.85), rgba(118, 75, 162, 0.85));
         padding: 2px;
+        box-sizing: border-box;
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
## Summary
- restructure the sidebar markup to align with the dashboard's glassmorphism styling
- group navigation links under titled sections and enhance the desktop user card presentation
- keep the offcanvas navigation consistent with the updated desktop experience

## Testing
- php -l sidebar.php

------
https://chatgpt.com/codex/tasks/task_e_68e4f06fea8883288b0bc391a6c514c9