### PR TITLE
Rename contact wording to company employees

### DIFF
--- a/company_contact.php
+++ b/company_contact.php
@@ -17,7 +17,7 @@ if ($company) {
     $contacts = $contactsStmt->fetchAll();
 }
 
-$pageTitle = 'İletişim Kişileri - Nexa';
+$pageTitle = 'Şirket Çalışanları - Nexa';
 $csrfToken = ensure_csrf_token();
 $hasSidebar = true;
 ?>
@@ -406,7 +406,7 @@ $hasSidebar = true;
                     <div>
                         <span class="text-uppercase fw-semibold small mb-2 d-inline-flex align-items-center gap-2">
                             <i class="bi bi-people"></i>
-                            İletişim Kişileri
+                            Şirket Çalışanları
                         </span>
                         <h1 class="mb-3">Şirket ağınızı kolayca yönetin</h1>
                         <p class="mb-0 opacity-75">Takım arkadaşlarınızı ve paydaşlarınızı tek bir yerden takip edin. Kişileri güncelleyin, yeni kişiler ekleyin ve iletişim bilgilerini paylaşın.</p>

--- a/dashboard.php
+++ b/dashboard.php
@@ -349,7 +349,7 @@ $hasSidebar = true;
                             <i class="bi bi-people"></i>
                         </div>
                         <div class="stat-value"><?= $contactCount ?></div>
-                        <div class="stat-label">İletişim Kişisi</div>
+                        <div class="stat-label">Şirket Çalışanları</div>
                     </div>
                 </div>
             </div>

--- a/sidebar.php
+++ b/sidebar.php
@@ -24,7 +24,7 @@ $navItems = [
     [
         'href' => 'company_contact.php',
         'icon' => 'bi-people',
-        'label' => 'İletişim Kişileri',
+        'label' => 'Şirket Çalışanları',
     ],
 ];
 


### PR DESCRIPTION
## Summary
- update the company contacts page title, heading, and navigation label to read “Şirket Çalışanları”
- align the dashboard statistic label with the new wording

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e51422653c8328b11f693041320716