### PR TITLE
Refine sidebar color palette

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -92,7 +92,7 @@ if (function_exists('mb_strtoupper')) {
     .sidebar .nav-link:hover:not(.active),
     #sidebarOffcanvas .nav-link:hover:not(.active) {
         background-color: var(--sidebar-hover);
-        color: var(--sidebar-text);
+        color: var(--sidebar-accent-contrast);
     }
 
     .sidebar .nav-link.active,

--- a/sidebar.php
+++ b/sidebar.php
@@ -57,24 +57,96 @@ if (function_exists('mb_strtoupper')) {
 }
 ?>
 <style>
+    .sidebar,
+    #sidebarOffcanvas {
+        --sidebar-accent: #4f46e5;
+        --sidebar-accent-contrast: #ffffff;
+        --sidebar-hover: rgba(79, 70, 229, 0.08);
+        --sidebar-surface: #ffffff;
+        --sidebar-muted: #6b7280;
+        --sidebar-text: #1f2937;
+        --sidebar-border: #e5e7eb;
+        background-color: var(--sidebar-surface);
+        color: var(--sidebar-text);
+    }
+
+    .sidebar .section-label,
+    #sidebarOffcanvas .section-label {
+        color: var(--sidebar-muted);
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+    }
+
     .sidebar .nav-link,
     #sidebarOffcanvas .nav-link {
+        align-items: center;
+        border-radius: 0.5rem;
+        color: var(--sidebar-muted);
+        display: flex;
+        gap: 0.5rem;
+        padding: 0.75rem 1rem;
+        text-decoration: none;
         transition: all 0.2s ease;
     }
 
     .sidebar .nav-link:hover:not(.active),
     #sidebarOffcanvas .nav-link:hover:not(.active) {
-        background-color: #f8f9fa !important;
+        background-color: var(--sidebar-hover);
+        color: var(--sidebar-text);
     }
-    
-    .sidebar .nav-link:hover:not(.active) *,
-    #sidebarOffcanvas .nav-link:hover:not(.active) * {
-        color: #000 !important;
+
+    .sidebar .nav-link.active,
+    #sidebarOffcanvas .nav-link.active {
+        background-color: var(--sidebar-accent);
+        color: var(--sidebar-accent-contrast);
+        font-weight: 600;
+        box-shadow: 0 0.5rem 1.5rem -1rem rgba(79, 70, 229, 0.6);
     }
-    
-    .sidebar .nav .nav-link:hover:not(.active),
-    #sidebarOffcanvas .nav .nav-link:hover:not(.active) {
-        background-color: #e9ecef !important;
+
+    .sidebar .nav-link.active i,
+    #sidebarOffcanvas .nav-link.active i,
+    .sidebar .nav-link.active span,
+    #sidebarOffcanvas .nav-link.active span {
+        color: inherit;
+    }
+
+    .sidebar .nav .nav-link,
+    #sidebarOffcanvas .nav .nav-link {
+        padding: 0.65rem 1rem;
+    }
+
+    .sidebar .nav .nav .nav-link.active,
+    #sidebarOffcanvas .nav .nav .nav-link.active {
+        background-color: rgba(79, 70, 229, 0.12);
+        color: var(--sidebar-accent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+
+    .sidebar .profile-initials,
+    #sidebarOffcanvas .profile-initials {
+        background-color: var(--sidebar-accent);
+        color: var(--sidebar-accent-contrast);
+    }
+
+    .sidebar .logout-btn,
+    #sidebarOffcanvas .logout-btn {
+        background-color: transparent;
+        border-radius: 0.5rem;
+        border-color: rgba(79, 70, 229, 0.4);
+        color: var(--sidebar-accent);
+    }
+
+    .sidebar .logout-btn:hover,
+    #sidebarOffcanvas .logout-btn:hover {
+        background-color: var(--sidebar-accent);
+        border-color: var(--sidebar-accent);
+        color: var(--sidebar-accent-contrast);
+    }
+
+    .sidebar .border-top,
+    #sidebarOffcanvas .border-top {
+        border-top-color: var(--sidebar-border) !important;
     }
 </style>
 <aside class="sidebar col-auto d-none d-lg-flex flex-column flex-shrink-0 align-self-start px-3 py-4 position-sticky top-0 min-vh-100 bg-white border-end" style="width: 260px;">
@@ -83,7 +155,7 @@ if (function_exists('mb_strtoupper')) {
         <div class="fw-bold">Nexa</div>
     </div>
     
-    <div class="text-secondary text-uppercase small mb-2 px-2" style="font-size: 0.7rem; letter-spacing: 0.5px;">Menü</div>
+    <div class="section-label small mb-2 px-2" style="font-size: 0.7rem;">Menü</div>
     
     <nav class="nav flex-column gap-1 mb-auto">
         <?php foreach ($navItems as $item): ?>
@@ -97,11 +169,9 @@ if (function_exists('mb_strtoupper')) {
                     }
                 }
                 $isActive = $currentPage === basename($item['href']) || $isChildActive;
-                $linkClasses = 'nav-link d-flex align-items-center gap-2 px-3 py-2 rounded text-decoration-none';
+                $linkClasses = 'nav-link px-3 py-2';
                 if ($isActive) {
-                    $linkClasses .= ' bg-dark text-white';
-                } else {
-                    $linkClasses .= ' text-body';
+                    $linkClasses .= ' active';
                 }
             ?>
             <div>
@@ -114,11 +184,9 @@ if (function_exists('mb_strtoupper')) {
                         <?php foreach ($childItems as $child): ?>
                             <?php
                                 $isChildLinkActive = $currentPage === basename($child['href']);
-                                $childClasses = 'nav-link px-3 py-2 rounded small text-decoration-none';
+                                $childClasses = 'nav-link px-3 py-2 small';
                                 if ($isChildLinkActive) {
-                                    $childClasses .= ' bg-light text-dark fw-medium';
-                                } else {
-                                    $childClasses .= ' text-secondary';
+                                    $childClasses .= ' active';
                                 }
                             ?>
                             <a class="<?= e($childClasses) ?>" href="<?= e($child['href']) ?>"<?php if ($isChildLinkActive): ?> aria-current="page"<?php endif; ?>>
@@ -133,17 +201,17 @@ if (function_exists('mb_strtoupper')) {
     
     <div class="mt-auto pt-3 border-top">
         <div class="d-flex align-items-center gap-2 mb-3 px-2">
-            <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center" style="width: 36px; height: 36px; font-size: 0.85rem;">
+            <div class="rounded-circle profile-initials d-flex align-items-center justify-content-center" style="width: 36px; height: 36px; font-size: 0.85rem;">
                 <?= e($initials) ?>
             </div>
             <div class="flex-grow-1 overflow-hidden">
                 <div class="fw-medium small text-truncate"><?= e(trim($firstName . ' ' . $lastName)) ?></div>
-                <div class="text-secondary small text-truncate" style="font-size: 0.75rem;">
+                <div class="text-secondary small text-truncate" style="font-size: 0.75rem; color: var(--sidebar-muted);">
                     <?= e($email) ?>
                 </div>
             </div>
         </div>
-        <a class="btn btn-outline-dark btn-sm w-100" href="logout.php">
+        <a class="btn btn-sm w-100 logout-btn" href="logout.php">
             <i class="bi bi-box-arrow-right me-1"></i>Çıkış
         </a>
     </div>
@@ -155,7 +223,7 @@ if (function_exists('mb_strtoupper')) {
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Kapat"></button>
     </div>
     <div class="offcanvas-body d-flex flex-column">
-        <div class="text-secondary text-uppercase small mb-2" style="font-size: 0.7rem; letter-spacing: 0.5px;">Menü</div>
+        <div class="section-label small mb-2" style="font-size: 0.7rem;">Menü</div>
         
         <nav class="nav flex-column gap-1 mb-4">
             <?php foreach ($navItems as $item): ?>
@@ -169,11 +237,9 @@ if (function_exists('mb_strtoupper')) {
                         }
                     }
                     $isActive = $currentPage === basename($item['href']) || $isChildActive;
-                    $linkClasses = 'nav-link d-flex align-items-center gap-2 px-3 py-2 rounded text-decoration-none';
+                    $linkClasses = 'nav-link px-3 py-2';
                     if ($isActive) {
-                        $linkClasses .= ' bg-dark text-white';
-                    } else {
-                        $linkClasses .= ' text-body';
+                        $linkClasses .= ' active';
                     }
                 ?>
                 <div>
@@ -186,11 +252,9 @@ if (function_exists('mb_strtoupper')) {
                             <?php foreach ($childItems as $child): ?>
                                 <?php
                                     $isChildLinkActive = $currentPage === basename($child['href']);
-                                    $childClasses = 'nav-link px-3 py-2 rounded small text-decoration-none';
+                                    $childClasses = 'nav-link px-3 py-2 small';
                                     if ($isChildLinkActive) {
-                                        $childClasses .= ' bg-light text-dark fw-medium';
-                                    } else {
-                                        $childClasses .= ' text-secondary';
+                                        $childClasses .= ' active';
                                     }
                                 ?>
                                 <a class="<?= e($childClasses) ?>" href="<?= e($child['href']) ?>"<?php if ($isChildLinkActive): ?> aria-current="page"<?php endif; ?>>
@@ -205,17 +269,17 @@ if (function_exists('mb_strtoupper')) {
         
         <div class="mt-auto border-top pt-3">
             <div class="d-flex align-items-center gap-2 mb-3">
-                <div class="rounded-circle bg-dark text-white d-flex align-items-center justify-content-center" style="width: 36px; height: 36px; font-size: 0.85rem;">
+                <div class="rounded-circle profile-initials d-flex align-items-center justify-content-center" style="width: 36px; height: 36px; font-size: 0.85rem;">
                     <?= e($initials) ?>
                 </div>
                 <div class="flex-grow-1 overflow-hidden">
                     <div class="fw-medium small text-truncate"><?= e(trim($firstName . ' ' . $lastName)) ?></div>
-                    <div class="text-secondary small text-truncate" style="font-size: 0.75rem;">
+                    <div class="text-secondary small text-truncate" style="font-size: 0.75rem; color: var(--sidebar-muted);">
                         <?= e($email) ?>
                     </div>
                 </div>
             </div>
-            <a class="btn btn-outline-dark btn-sm w-100" href="logout.php">
+            <a class="btn btn-sm w-100 logout-btn" href="logout.php">
                 <i class="bi bi-box-arrow-right me-1"></i>Çıkış
             </a>
         </div>


### PR DESCRIPTION
## Summary
- introduce a cohesive sidebar color system driven by CSS custom properties
- update active, hover, and button states to use the shared accent palette across desktop and offcanvas views
- restyle profile avatar and logout button to align with the refreshed visual theme

## Testing
- php -l sidebar.php

------
https://chatgpt.com/codex/tasks/task_e_68e51fd749a08328823380bc5916b187